### PR TITLE
Simplify standard and advanced navigation

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { SettingsPanel } from "@/components/settings-panel";
 export default function SettingsPage() {
   return (
     <div className="page-frame">
-      <PageHeading title="Settings" description="Manage models, tool connections, appearance, and local data without exposing secrets." />
+      <PageHeading title="Settings" description="Manage your AI service, privacy, appearance, and advanced controls." />
       <SettingsPanel />
     </div>
   );

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { trapFocus } from "@/lib/focus";
+import { useExperienceMode } from "@/lib/experience-mode";
 import {
   Archive,
   ChevronLeft,
@@ -21,15 +22,13 @@ import {
 } from "lucide-react";
 
 const navigation = [
-  { href: "/", label: "Home", icon: Home, exact: true },
+  { href: "/", label: "Workspace", icon: Home, exact: true },
   { href: "/chat", label: "Chat", icon: MessageCircle },
-  { href: "/memory", label: "Memory", icon: NotebookTabs },
-  { href: "/repository", label: "Outcomes", icon: Archive },
+  { href: "/memory", label: "Memory control", icon: NotebookTabs, advancedOnly: true },
+  { href: "/repository", label: "Results", icon: Archive },
   { href: "/projects", label: "Projects", icon: FolderKanban },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
-
-const mobileNavigation = navigation.filter((item) => ["/", "/chat", "/projects"].includes(item.href));
 
 type InstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -37,6 +36,8 @@ type InstallPromptEvent = Event & {
 };
 
 function SidebarContent({ pathname, onNavigate }: { pathname: string; onNavigate?: () => void }) {
+  const experienceMode = useExperienceMode();
+  const visibleNavigation = navigation.filter((item) => experienceMode === "advanced" || !item.advancedOnly);
   return (
     <div className="flex h-full flex-col">
       <Link href="/" className="flex min-h-12 items-center gap-3 rounded-control" onClick={onNavigate}>
@@ -47,7 +48,7 @@ function SidebarContent({ pathname, onNavigate }: { pathname: string; onNavigate
       </Link>
 
       <nav className="mt-10 space-y-1" aria-label="Primary navigation">
-        {navigation.map((item) => {
+        {visibleNavigation.map((item) => {
           const active = item.exact ? pathname === item.href : pathname.startsWith(item.href);
           const Icon = item.icon;
           return (
@@ -96,6 +97,7 @@ function SidebarContent({ pathname, onNavigate }: { pathname: string; onNavigate
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const experienceMode = useExperienceMode();
   const [moreOpen, setMoreOpen] = useState(false);
   const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(null);
   const [iosInstallAvailable, setIosInstallAvailable] = useState(false);
@@ -103,6 +105,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const sheetRef = useRef<HTMLElement>(null);
   const moreTriggerRef = useRef<HTMLButtonElement>(null);
   const focusedChat = pathname.startsWith("/chat");
+  const visibleNavigation = navigation.filter((item) => experienceMode === "advanced" || !item.advancedOnly);
+  const mobileNavigation = visibleNavigation.filter((item) => ["/", "/chat", "/projects"].includes(item.href));
 
   useEffect(() => { setMoreOpen(false); setShowInstallHelp(false); }, [pathname]);
 
@@ -213,7 +217,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                   </button>
                 )}
                 {!installPrompt && iosInstallAvailable && <button type="button" className="flex min-h-14 items-center gap-3 rounded-control bg-accent-soft px-4 text-left text-sm font-medium text-accent-hover" onClick={() => setShowInstallHelp(true)}><SquarePlus aria-hidden size={19} strokeWidth={1.7} />Install on iPhone</button>}
-                {navigation.filter((item) => ["/memory", "/repository", "/settings"].includes(item.href)).map((item) => {
+                {visibleNavigation.filter((item) => ["/memory", "/repository", "/settings"].includes(item.href)).map((item) => {
                   const Icon = item.icon;
                   return <Link key={item.href} href={item.href} className="flex min-h-14 items-center gap-3 rounded-control bg-surface-subtle/60 px-4 text-sm font-medium" onClick={closeMore}><Icon aria-hidden size={19} strokeWidth={1.7} />{item.label}</Link>;
                 })}

--- a/apps/web/components/chat-workspace.tsx
+++ b/apps/web/components/chat-workspace.tsx
@@ -28,6 +28,7 @@ import { ModelSelector, type ProviderOption } from "@/components/model-selector"
 import { RichMessage } from "@/components/rich-message";
 import { ErrorState } from "@/components/ui-states";
 import { apiJson, type SseEvent, streamSse } from "@/lib/api";
+import { useExperienceMode } from "@/lib/experience-mode";
 import { focusableSelector, trapFocus } from "@/lib/focus";
 
 type Project = { id: string; name: string; description: string };
@@ -50,6 +51,7 @@ const starterPrompts = [
 ];
 
 export function ChatWorkspace() {
+  const experienceMode = useExperienceMode();
   const [providers, setProviders] = useState<ProviderOption[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -88,6 +90,10 @@ export function ChatWorkspace() {
   const peerRef = useRef<RTCPeerConnection | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    if (experienceMode === "standard") setUseMcp(false);
+  }, [experienceMode]);
   const inputTranscriptRef = useRef("");
   const outputTranscriptRef = useRef("");
   const savedLiveItemsRef = useRef(new Set<string>());
@@ -568,7 +574,7 @@ export function ChatWorkspace() {
               {providers.length > 0 && !providerReady && <div className="mx-auto mb-2 flex max-w-[780px] items-center justify-between gap-3 rounded-control bg-warning/10 px-3 py-2 text-xs text-warning"><span>{selectedProvider?.id === "anthropic" ? "Anthropic" : "OpenAI"} needs a server-side credential before messages can be sent.</span><Link href="/settings#models-settings" className="shrink-0 font-medium underline underline-offset-2">Open Settings</Link></div>}
               <div className="mx-auto max-w-[780px] rounded-[22px] border border-line-strong bg-surface-elevated p-2 shadow-composer focus-within:border-accent">
                 <textarea className="scrollbar-subtle max-h-40 min-h-[48px] w-full resize-none bg-transparent px-2 py-2 text-[15px] leading-6 outline-none placeholder:text-text-tertiary" placeholder="Ask anything…" aria-label="Message" value={input} rows={1} onChange={(event) => setInput(event.target.value)} />
-                <div className="flex items-center gap-1"><button type="button" className="icon-button" disabled title="Attachments are planned" aria-label="Attach a file (planned)"><Paperclip aria-hidden size={18} /></button><button type="button" className={`icon-button ${useMcp ? "bg-accent-soft text-accent" : ""}`} onClick={() => setUseMcp((current) => !current)} aria-pressed={useMcp} aria-label="Use a tool"><Wrench aria-hidden size={18} /></button><button className="button-primary ml-auto size-10 min-h-10 px-0" aria-label={running ? "Sending message" : "Send message"} disabled={!input.trim() || !model || !providerReady || running || (useMcp && !toolName)}><Send aria-hidden size={17} /></button></div>
+                <div className="flex items-center gap-1"><button type="button" className="icon-button" disabled title="Attachments are planned" aria-label="Attach a file (planned)"><Paperclip aria-hidden size={18} /></button>{experienceMode === "advanced" && <button type="button" className={`icon-button ${useMcp ? "bg-accent-soft text-accent" : ""}`} onClick={() => setUseMcp((current) => !current)} aria-pressed={useMcp} aria-label="Use an advanced tool"><Wrench aria-hidden size={18} /></button>}<button className="button-primary ml-auto size-10 min-h-10 px-0" aria-label={running ? "Sending message" : "Send message"} disabled={!input.trim() || !model || !providerReady || running || (useMcp && !toolName)}><Send aria-hidden size={17} /></button></div>
               </div>
             </form>
           </>

--- a/apps/web/components/settings-panel.tsx
+++ b/apps/web/components/settings-panel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { FormEvent, useEffect, useMemo, useState } from "react";
-import { Cable, Check, ChevronDown, Database, Mic2, Palette, Plus, RefreshCw, Server, ShieldCheck, Smartphone } from "lucide-react";
+import { Cable, Check, ChevronDown, Database, Gauge, Mic2, Palette, Plus, RefreshCw, Server, ShieldCheck, Smartphone } from "lucide-react";
 import { apiJson } from "@/lib/api";
+import { setExperienceMode, useExperienceMode } from "@/lib/experience-mode";
 import { ErrorState, LoadingState } from "@/components/ui-states";
 
 type Provider = { id: string; configured: boolean; models: string[] };
@@ -43,6 +44,7 @@ function providerName(id: string) {
 }
 
 export function SettingsPanel() {
+  const experienceMode = useExperienceMode();
   const [settings, setSettings] = useState<Settings>();
   const [provider, setProvider] = useState("");
   const [model, setModel] = useState("");
@@ -87,6 +89,26 @@ export function SettingsPanel() {
     });
   }, []);
   const selected = useMemo(() => settings?.providers.find((item) => item.id === provider), [provider, settings]);
+  const interfaceModeCard = (
+    <section className="panel p-4 sm:p-5" aria-labelledby="interface-mode-settings">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex gap-3">
+          <Gauge aria-hidden size={19} className="mt-0.5 shrink-0 text-text-tertiary" />
+          <div>
+            <h2 id="interface-mode-settings" className="section-title">Interface mode</h2>
+            <p className="mt-1 text-sm leading-6 text-text-secondary">
+              {experienceMode === "standard" ? "Standard keeps technical controls out of your daily workflow." : "Advanced shows model, memory, connector, and tool controls."}
+            </p>
+          </div>
+        </div>
+        <div className="grid min-w-[248px] grid-cols-2 rounded-control bg-surface-subtle p-1" role="group" aria-label="Interface mode">
+          {(["standard", "advanced"] as const).map((mode) => (
+            <button key={mode} type="button" className={`min-h-10 rounded-small px-3 text-sm font-medium capitalize transition-colors ${experienceMode === mode ? "bg-surface-elevated text-text-primary shadow-soft" : "text-text-secondary hover:text-text-primary"}`} aria-pressed={experienceMode === mode} onClick={() => setExperienceMode(mode)}>{mode}</button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 
   async function submitDefaults(event: FormEvent) {
     event.preventDefault();
@@ -167,16 +189,17 @@ export function SettingsPanel() {
     await load();
   }
 
-  if (loadError) return <ErrorState title="Settings are unavailable" detail="Safe configuration could not be loaded. Start the API and refresh this page." />;
-  if (!settings) return <LoadingState label="Loading safe configuration" />;
+  if (loadError) return <div className="space-y-6">{interfaceModeCard}<ErrorState title="AI service settings are unavailable" detail="The interface mode still works. Start the local API to manage AI services and tool connections." /></div>;
+  if (!settings) return <div className="space-y-6">{interfaceModeCard}<LoadingState label="Loading safe configuration" /></div>;
 
   return (
     <div className="space-y-8 sm:space-y-10">
+      {interfaceModeCard}
       <nav className="scrollbar-subtle -mx-1 flex gap-2 overflow-x-auto px-1 pb-1" aria-label="Settings sections">
-        {[{ href: "#models-settings", label: "Models" }, { href: "#mcp-settings", label: "MCP" }, { href: "#appearance-settings", label: "Appearance" }, { href: "#data-settings", label: "Data" }].map((item) => <a key={item.href} href={item.href} className="chip min-h-11 shrink-0 hover:bg-accent-soft hover:text-accent-hover">{item.label}</a>)}
+        {[{ href: "#models-settings", label: "AI service" }, ...(experienceMode === "advanced" ? [{ href: "#mcp-settings", label: "Tool connections" }] : []), { href: "#appearance-settings", label: "Appearance" }, { href: "#data-settings", label: "Data & privacy" }].map((item) => <a key={item.href} href={item.href} className="chip min-h-11 shrink-0 hover:bg-accent-soft hover:text-accent-hover">{item.label}</a>)}
       </nav>
       <section className="scroll-mt-6" aria-labelledby="models-settings">
-        <div className="mb-4 flex items-center gap-2"><Server aria-hidden size={18} className="text-text-tertiary" /><h2 id="models-settings" className="section-title">Models</h2></div>
+        <div className="mb-4 flex items-center gap-2"><Server aria-hidden size={18} className="text-text-tertiary" /><h2 id="models-settings" className="section-title">AI service</h2></div>
         {!settings.providers.some((item) => item.configured) && (
           <div className="panel mb-4 border-accent/30 bg-accent-soft/45 p-4 sm:p-5">
             <p className="eyebrow">First run</p>
@@ -212,9 +235,9 @@ export function SettingsPanel() {
             })}
           </div>
           <form onSubmit={submitDefaults} className="panel p-4 sm:p-5">
-            <h3 className="text-[15px] font-medium">Default model</h3>
+            <h3 className="text-[15px] font-medium">Default AI</h3>
             <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-              <label className="text-xs font-medium text-text-secondary">Provider
+              <label className="text-xs font-medium text-text-secondary">AI service
                 <select className="field mt-1.5 w-full" value={provider} onChange={(event) => { const id = event.target.value; setProvider(id); setModel(settings.providers.find((item) => item.id === id)?.models[0] || ""); }}>
                   {settings.providers.map((item) => <option key={item.id} value={item.id}>{providerName(item.id)}</option>)}
                 </select>
@@ -231,11 +254,11 @@ export function SettingsPanel() {
         </div>
       </section>
 
-      <section className="scroll-mt-6" aria-labelledby="mcp-settings">
+      {experienceMode === "advanced" && <section className="scroll-mt-6" aria-labelledby="mcp-settings">
         <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
           <div>
-            <div className="flex items-center gap-2"><Cable aria-hidden size={18} className="text-text-tertiary" /><h2 id="mcp-settings" className="section-title">MCP</h2></div>
-            <p className="mt-2 text-sm leading-6 text-text-secondary">Allowlisted tool connections available to your workspace.</p>
+            <div className="flex items-center gap-2"><Cable aria-hidden size={18} className="text-text-tertiary" /><h2 id="mcp-settings" className="section-title">Tool connections <span className="chip ml-2 align-middle">Advanced</span></h2></div>
+            <p className="mt-2 text-sm leading-6 text-text-secondary">Manage MCP connectors and their allowlisted tools.</p>
           </div>
           <details className="group relative">
             <summary className="button-primary cursor-pointer list-none"><Plus aria-hidden size={17} />Add connector</summary>
@@ -294,7 +317,7 @@ export function SettingsPanel() {
             </article>
           ))}
         </div>
-      </section>
+      </section>}
 
       <div className="grid gap-4 sm:grid-cols-2">
         <section className="panel scroll-mt-6 p-4 sm:p-5" aria-labelledby="appearance-settings">
@@ -302,7 +325,7 @@ export function SettingsPanel() {
           <div className="mt-5 flex items-center justify-between rounded-control bg-surface-subtle p-4"><span className="text-sm font-medium">Theme</span><span className="chip">Light</span></div>
         </section>
         <section className="panel scroll-mt-6 p-4 sm:p-5" aria-labelledby="data-settings">
-          <div className="flex items-center gap-2"><Database aria-hidden size={18} className="text-text-tertiary" /><h2 id="data-settings" className="section-title">Data</h2></div>
+          <div className="flex items-center gap-2"><Database aria-hidden size={18} className="text-text-tertiary" /><h2 id="data-settings" className="section-title">Data & privacy</h2></div>
           <div className="mt-5 flex gap-3 rounded-control bg-surface-subtle p-4"><ShieldCheck aria-hidden size={18} className="mt-0.5 shrink-0 text-success" /><div><p className="text-sm font-medium">Local persistence</p><p className="mt-1 text-xs leading-5 text-text-secondary">Conversation, memory, and repository data remain managed by the local API. Secret values are never exposed here.</p></div></div>
         </section>
         <section className="panel scroll-mt-6 p-4 sm:col-span-2 sm:p-5" aria-labelledby="mobile-settings">

--- a/apps/web/lib/experience-mode.ts
+++ b/apps/web/lib/experience-mode.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export type ExperienceMode = "standard" | "advanced";
+
+const storageKey = "personal-ai-os:experience-mode";
+const modeChangedEvent = "personal-ai-os:experience-mode-changed";
+
+function getMode(): ExperienceMode {
+  if (typeof window === "undefined") return "standard";
+  return window.localStorage.getItem(storageKey) === "advanced" ? "advanced" : "standard";
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener("storage", callback);
+  window.addEventListener(modeChangedEvent, callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    window.removeEventListener(modeChangedEvent, callback);
+  };
+}
+
+export function setExperienceMode(mode: ExperienceMode) {
+  window.localStorage.setItem(storageKey, mode);
+  window.dispatchEvent(new Event(modeChangedEvent));
+}
+
+export function useExperienceMode() {
+  return useSyncExternalStore(subscribe, getMode, () => "standard" as ExperienceMode);
+}


### PR DESCRIPTION
## What changed

- add a locally persisted Standard / Advanced interface mode
- keep technical memory, MCP connector, and manual tool controls out of the default daily workflow
- rename everyday navigation and settings terms around Workspace, Results, AI service, and Data & privacy
- keep interface mode switching available when the local API is offline

## Why

The product currently exposes engineering concepts in the default experience. This small change creates a clearer ordinary-user surface without removing advanced self-hosted capabilities.

## Validation

- `pnpm check:web`
- `pnpm build:web`
- rendered navigation checks at 390px and 1440px
- verified Standard hides Memory control and manual tool entry; Advanced restores them

## Known boundary

The visual preview ran without the local API, so AI service data and live connector actions were not exercised in-browser. The page's offline fallback and mode switch were verified.