### PR TITLE
chore: align stable release line to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to Personal AI OS are documented here.
 
 This project follows Semantic Versioning for public releases.
 
-## [0.1.0] - Unreleased
+## [0.2.0] - Unreleased
+
+This stable candidate continues the version line established by the historical `v0.2.0-alpha.1` tag. That alpha tag remains part of repository history; no GitHub Release was published for it.
 
 ### Added
 
@@ -30,4 +32,4 @@ This project follows Semantic Versioning for public releases.
 
 ### Release gate
 
-`v0.1.0` must not be published until the release checklist in `docs/release-checklist.md` passes, including a real-provider fresh-install smoke test. Until then this section remains `Unreleased`.
+`v0.2.0` must not be published until the release checklist in `docs/release-checklist.md` passes, including a real-provider fresh-install smoke test. Until then this section remains `Unreleased`.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -4,17 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-ai-os-api"
-version = "0.1.0"
+version = "0.2.0"
 description = "FastAPI modular-monolith API for Personal AI OS"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi>=0.115,<1",
   "httpx>=0.28,<1",
   "uvicorn[standard]>=0.34,<1",
-  "personal-ai-os-core==0.1.0",
-  "personal-ai-os-providers==0.1.0",
-  "personal-ai-os-mcp==0.1.0",
-  "personal-ai-os-projects==0.1.0",
+  "personal-ai-os-core==0.2.0",
+  "personal-ai-os-providers==0.2.0",
+  "personal-ai-os-mcp==0.2.0",
+  "personal-ai-os-projects==0.2.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@personal-ai-os/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,7 +2,13 @@
 
 This checklist is the publication gate for Personal AI OS releases. A release is not considered ready because CI is green alone.
 
-## v0.1.0 gate
+## v0.2.0 gate
+
+### Version history
+
+- [x] Historical tag `v0.2.0-alpha.1` exists and is an ancestor of current `main`.
+- [x] No GitHub Release was published for `v0.2.0-alpha.1`; the tag remains intact as historical prerelease evidence.
+- [x] The next stable release line is `v0.2.0`, not a chronological rollback to `v0.1.0`.
 
 ### Source and repository
 
@@ -10,7 +16,7 @@ This checklist is the publication gate for Personal AI OS releases. A release is
 - [x] `main` contains Standard / Advanced navigation.
 - [x] Apache-2.0 license, `SECURITY.md`, and `CONTRIBUTING.md` are present.
 - [x] Public README documents local startup, checks, privacy boundaries, and current runnable scope.
-- [x] Package/API version is `0.1.0`.
+- [x] API, internal Python packages, and Web package are aligned to version `0.2.0` in the release candidate.
 - [ ] `CHANGELOG.md` is switched from `Unreleased` to the actual release date immediately before tagging.
 
 ### Automated verification
@@ -25,8 +31,8 @@ pnpm build:web
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-mobile-readiness.ps1 -BaseUrl "http://127.0.0.1:3001" -AllowInsecureLocalhost
 ```
 
-- [x] Latest `main` GitHub Actions CI is green after merging the v0.1.0 feature work.
-- [ ] Clean-checkout verification above has been rerun for the release candidate.
+- [x] Latest `main` GitHub Actions CI is green after merging the core v0.2 feature work and release-gate documentation.
+- [ ] Clean-checkout verification above has been rerun for the final release candidate after version alignment.
 
 ### Fresh-install real-provider smoke test
 
@@ -54,10 +60,10 @@ Only after every required box above passes:
 1. Replace `Unreleased` in `CHANGELOG.md` with the release date.
 2. Merge the final release-prep change to `main` and require green CI.
 3. Close Issue #1 only if its real fresh-install/provider acceptance criteria are actually satisfied.
-4. Create tag `v0.1.0` from the verified `main` commit.
-5. Publish GitHub Release `v0.1.0` with concise release notes and known limitations.
+4. Create tag `v0.2.0` from the verified `main` commit.
+5. Publish GitHub Release `v0.2.0` with concise release notes and known limitations.
 6. Verify the release tag points to the intended commit and no secret/private artifact is attached.
 
 ## Fail-closed rule
 
-If the real-provider smoke test cannot be executed because no usable credential/environment is available, keep Issue #1 open and do not publish `v0.1.0`. All non-secret automated and repository checks may still be completed in advance.
+If the real-provider smoke test cannot be executed because no usable credential/environment is available, keep Issue #1 open and do not publish `v0.2.0`. All non-secret automated and repository checks may still be completed in advance.

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-ai-os-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Provider- and project-neutral contracts for Personal AI OS"
 requires-python = ">=3.11"
 dependencies = ["pydantic>=2.10,<3"]

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-ai-os-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Allowlisted MCP gateway for Personal AI OS"
 requires-python = ">=3.11"
 dependencies = [
   "httpx>=0.28,<1",
   "pydantic>=2.10,<3",
-  "personal-ai-os-core==0.1.0",
+  "personal-ai-os-core==0.2.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/projects/pyproject.toml
+++ b/packages/projects/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-ai-os-projects"
-version = "0.1.0"
+version = "0.2.0"
 description = "Project plugins for Personal AI OS"
 requires-python = ">=3.11"
-dependencies = ["personal-ai-os-core==0.1.0"]
+dependencies = ["personal-ai-os-core==0.2.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/providers/pyproject.toml
+++ b/packages/providers/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-ai-os-providers"
-version = "0.1.0"
+version = "0.2.0"
 description = "Streaming provider adapters for Personal AI OS"
 requires-python = ">=3.11"
 dependencies = [
   "httpx>=0.28,<1",
-  "personal-ai-os-core==0.1.0",
+  "personal-ai-os-core==0.2.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Why

The repository already contains the historical tag `v0.2.0-alpha.1`, and that tagged commit explicitly described the project as an early V0.2 prototype. The tag is an ancestor of current `main`, while no GitHub Release was published for it.

Preparing a later `v0.1.0` stable release would therefore create a confusing chronological version rollback. This PR preserves the historical alpha tag and aligns the next stable release candidate to `v0.2.0`.

## What changed

- bump API package from `0.1.0` to `0.2.0`
- bump `core`, `providers`, `mcp`, and `projects` packages to `0.2.0`
- align all exact internal Python package dependencies to `0.2.0`
- bump private Web package metadata to `0.2.0`
- correct `CHANGELOG.md` from `v0.1.0` to `v0.2.0`
- correct the fail-closed release checklist to target `v0.2.0`
- document that `v0.2.0-alpha.1` remains intact as historical prerelease evidence

## Boundaries

- no functional source code changes
- no deletion or rewriting of the existing alpha tag
- no GitHub Release or stable tag is created by this PR
- the real-provider fresh-install smoke test remains mandatory before Issue #1 is closed or `v0.2.0` is published

## Validation

Merge only after CI is green.