### PR TITLE
docs: add early tester feedback funnel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,13 @@
 Thank you for helping improve Personal AI OS. Contributions should keep the core
 general-purpose, local-first, auditable, and safe for private user data.
 
+## Good first contributions
+
+If you are new to the project, the highest-value contribution is to try a fresh install and report
+real setup or first-chat friction in [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7).
+Small documentation corrections and focused bug fixes are also welcome. Please do not create
+synthetic feedback or test data that could be mistaken for real user adoption.
+
 ## Before opening a change
 
 - Search existing issues before starting overlapping work.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Personal AI OS
 
+[![CI](https://github.com/sui-ni2/personal-ai-os/actions/workflows/ci.yml/badge.svg)](https://github.com/sui-ni2/personal-ai-os/actions/workflows/ci.yml)
+
 A user-controlled AI workspace for long-running projects. It preserves context, helps complete
 work, and turns useful results into reusable outcomes while keeping memory decisions visible to
 the user. One modular core supports a community/self-hosted delivery mode today and a fail-closed
 managed cloud boundary for future account-based delivery.
 
 ![Personal AI OS flow](apps/web/public/assets/personal-ai-flow.png)
+
+## Early testers wanted
+
+Personal AI OS is preparing its first stable `v0.2.0` release. The most useful contribution right
+now is a genuine fresh-install test: configure a supported provider, complete one text-chat turn,
+restart the app, and report any setup friction or reproducible bug.
+
+- Testers: use [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7) for sanitized feedback.
+- Contributors: focused documentation fixes, bug fixes, and small pull requests are welcome.
+- Never post API keys, `.env` files, authorization headers, cookies, private conversations,
+  runtime databases, logs containing secrets, uploads/backups, or private project data.
 
 ## What is runnable now
 

--- a/docs/release-notes-v0.2.0-draft.md
+++ b/docs/release-notes-v0.2.0-draft.md
@@ -1,0 +1,42 @@
+# Personal AI OS v0.2.0 — Release Notes Draft
+
+> **Draft only. Do not publish this as a GitHub Release until every item in `docs/release-checklist.md` passes.**
+
+Personal AI OS is a user-controlled, local-first AI workspace for long-running projects. The `v0.2.0` stable line focuses on making the current community/self-hosted edition usable, auditable, and safe enough for genuine early-user testing while preserving fail-closed boundaries for future managed-cloud delivery.
+
+## Highlights
+
+- Next.js web workspace with Chat, Memory, Repository, Projects, and Settings.
+- Text chat and GPT Live conversation modes with restart-safe conversation history.
+- OpenAI and Anthropic adapters behind one provider-independent streaming interface.
+- Server-side credential handling, connection checks, and persistent default provider/model selection.
+- Standard and Advanced interface modes.
+- Project-scoped persistent state, version history, workflow gates, and project-bound MCP continuity tools.
+- Allowlisted MCP gateway supporting HTTP and fixed-command-alias stdio connectors.
+- General, Soccer, and isolated P5 project plugins under one project contract.
+- Tenant-scoped core persistence and explicit community/cloud product boundaries.
+- Installable mobile PWA shell and documented HTTPS deployment path.
+
+## Security and privacy
+
+- Provider credentials stay server-side and are not returned by Settings.
+- Runtime databases, private conversations, logs, uploads, backups, and private project data are not part of the public source distribution.
+- Audit surfaces redact credentials, authorization data, cookies, tracebacks, and reasoning fields.
+- MCP tools are allowlisted; models cannot submit arbitrary shell commands.
+- Cloud mode fails closed until real account identity is available.
+
+## Known limitations
+
+- The current runnable distribution is the community/self-hosted edition.
+- Cloud accounts, billing, managed provider routing, and device sync are not yet live.
+- Provider calls require user-supplied server-side credentials.
+- GPT Live and phone installation require a trusted HTTPS deployment for real-device use.
+- The stable release must not be published until the real-provider fresh-install smoke test and final privacy/artifact audit pass.
+
+## Verification before publication
+
+See `docs/release-checklist.md`. Required release evidence includes clean-checkout automated checks, an isolated real-provider fresh-install test, restart/persistence verification, and a final no-secrets/private-artifacts audit.
+
+## Feedback
+
+Early users should report sanitized fresh-install and first-chat feedback in Issue #7. Never include API keys, `.env` files, authorization headers, cookies, private conversations, runtime databases, or secret-bearing logs in public reports.


### PR DESCRIPTION
## Why

The repository has a clear release gate but no prominent path for genuine external users to test the first-run flow and report sanitized feedback.

## What changed

- add the CI status badge near the top of the README
- add an **Early testers wanted** section
- route genuine fresh-install feedback to Issue #7
- add a **Good first contributions** path in `CONTRIBUTING.md`
- add a fail-closed `v0.2.0` release-notes draft so publication is fast once the real smoke-test gate passes
- restate the no-secrets/no-private-data boundary for public reports

## Intent

This does not manufacture adoption signals. It lowers the friction for real users to test the project, file useful feedback, and contribute focused fixes while keeping the `v0.2.0` fail-closed release gate intact.