### PR TITLE
ci: add manual real-provider release smoke gate

### DIFF
--- a/.github/workflows/release-provider-smoke.yml
+++ b/.github/workflows/release-provider-smoke.yml
@@ -1,0 +1,48 @@
+name: Release provider smoke probe
+
+on:
+  push:
+    branches:
+      - chore/provider-smoke-gate
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  provider-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PERSONAL_AI_OS_OPENAI_API_KEY: ${{ secrets.PERSONAL_AI_OS_OPENAI_API_KEY }}
+      PERSONAL_AI_OS_ANTHROPIC_API_KEY: ${{ secrets.PERSONAL_AI_OS_ANTHROPIC_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Select configured provider without exposing secrets
+        id: provider
+        shell: bash
+        run: |
+          if [[ -n "$PERSONAL_AI_OS_OPENAI_API_KEY" ]]; then
+            echo "provider=openai" >> "$GITHUB_OUTPUT"
+            echo "Using configured OpenAI repository secret."
+          elif [[ -n "$PERSONAL_AI_OS_ANTHROPIC_API_KEY" ]]; then
+            echo "provider=anthropic" >> "$GITHUB_OUTPUT"
+            echo "Using configured Anthropic repository secret."
+          else
+            echo "::error title=Real provider smoke blocked::Neither PERSONAL_AI_OS_OPENAI_API_KEY nor PERSONAL_AI_OS_ANTHROPIC_API_KEY is configured as a repository Actions secret."
+            exit 1
+          fi
+
+      - name: Run isolated real-provider release smoke
+        run: python scripts/release-provider-smoke.py --provider "${{ steps.provider.outputs.provider }}"

--- a/.github/workflows/release-provider-smoke.yml
+++ b/.github/workflows/release-provider-smoke.yml
@@ -1,9 +1,6 @@
-name: Release provider smoke probe
+name: Release provider smoke
 
 on:
-  push:
-    branches:
-      - chore/provider-smoke-gate
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

`v0.2.0` still requires one genuine provider-backed fresh-install/restart smoke test. A probe run confirmed the repository currently has neither `PERSONAL_AI_OS_OPENAI_API_KEY` nor `PERSONAL_AI_OS_ANTHROPIC_API_KEY` configured as an Actions secret, so the real model call correctly failed closed.

## What this PR adds

- a permanent manual `Release provider smoke` GitHub Actions workflow
- repository-secret-only credential injection; secret values are never printed or written to the repository
- automatic provider selection (OpenAI preferred, Anthropic fallback)
- execution of the existing isolated `scripts/release-provider-smoke.py` gate
- no push trigger, so ordinary CI does not consume provider quota

## Probe evidence

The isolated probe installed all dependencies successfully, then stopped at the credential-selection step because both repository secret variables were empty. The real-provider step was skipped rather than fabricated.

After one supported provider key is added as a repository Actions secret, the gate can be re-run without further code changes.