### PR TITLE
test: make no-key first-run readiness a CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: python -m pytest apps/api/tests -q
       - name: Compile Python sources
         run: python -m compileall -q apps/api/src packages
+      - name: Verify fresh no-key readiness
+        run: python scripts/release-provider-smoke.py --provider openai --no-key-only
 
   frontend:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,18 @@ real setup or first-chat friction in [Issue #7](https://github.com/sui-ni2/perso
 Small documentation corrections and focused bug fixes are also welcome. Please do not create
 synthetic feedback or test data that could be mistaken for real user adoption.
 
+You do **not** need a paid provider API key to verify the safe first-run path. After installing the
+Python dependencies, run:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\release-provider-smoke.py --provider openai --no-key-only
+```
+
+This starts an isolated temporary API runtime with provider credentials stripped, verifies the
+`v0.2.0` health contract, confirms the selected provider remains unconfigured, and confirms secret
+values are not exposed through Settings. It makes no billable model call and deletes its temporary
+runtime data when complete.
+
 ## Before opening a change
 
 - Search existing issues before starting overlapping work.
@@ -41,6 +53,7 @@ request:
 ```powershell
 .\.venv\Scripts\python.exe -m pytest apps/api/tests -q
 .\.venv\Scripts\python.exe -m compileall -q apps/api/src packages
+.\.venv\Scripts\python.exe scripts\release-provider-smoke.py --provider openai --no-key-only
 pnpm check:web
 pnpm build:web
 ```

--- a/scripts/release-provider-smoke.py
+++ b/scripts/release-provider-smoke.py
@@ -176,10 +176,10 @@ def _assert_conversation(client: httpx.Client, conversation_id: str, minimum_mes
         _fail("Provider returned an empty assistant message")
 
 
-def run(provider: str, requested_model: str | None) -> None:
+def run(provider: str, requested_model: str | None, *, no_key_only: bool = False) -> None:
     if provider not in KEY_ENV:
         _fail(f"Unsupported provider: {provider}")
-    if not os.getenv(KEY_ENV[provider]):
+    if not no_key_only and not os.getenv(KEY_ENV[provider]):
         _fail(f"Set {KEY_ENV[provider]} in the current shell; the script never prints or writes its value")
 
     with tempfile.TemporaryDirectory(prefix="personal-ai-os-release-smoke-") as temp_dir:
@@ -202,6 +202,10 @@ def run(provider: str, requested_model: str | None) -> None:
             _pass("fresh install starts safely with provider unconfigured and secrets hidden")
         finally:
             _stop_api(process)
+
+        if no_key_only:
+            _pass("no-key readiness gate completed without provider credentials or billable model calls")
+            return
 
         # Phase 2: restart with the real credential and exercise a complete chat turn.
         process, base_url = _start_api(_environment(data_dir, provider=provider, include_credential=True))
@@ -258,13 +262,18 @@ def run(provider: str, requested_model: str | None) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Fail-closed v0.2.0 real-provider smoke test. Never prints provider credentials or response text."
+        description="Fail-closed v0.2.0 readiness smoke test. Never prints provider credentials or response text."
     )
     parser.add_argument("--provider", choices=sorted(KEY_ENV), default="openai")
     parser.add_argument("--model", default=None, help="Optional allowlisted model override")
+    parser.add_argument(
+        "--no-key-only",
+        action="store_true",
+        help="Verify fresh no-key startup and secret boundaries without requiring a provider credential or making billable model calls.",
+    )
     args = parser.parse_args()
     try:
-        run(args.provider, args.model)
+        run(args.provider, args.model, no_key_only=args.no_key_only)
     except SmokeFailure as exc:
         print(f"[FAIL] {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Why

The repository should remain testable by contributors even when they do not have a paid OpenAI or Anthropic API key. The real-provider release smoke remains fail-closed, but the safe no-key first-run path can and should be verified continuously.

## What changed

- add `--no-key-only` to `scripts/release-provider-smoke.py`
- allow the smoke runner to validate fresh startup, v0.2.0 health, unconfigured-provider state, and secret redaction without requiring a provider credential
- run that zero-cost readiness gate in backend CI on every push/PR
- document the no-key contributor command in `CONTRIBUTING.md`

## Safety / cost

The no-key mode strips provider credentials from the child API process, makes no billable model calls, and uses an isolated temporary runtime directory that is deleted after the check.

The existing manual real-provider release gate is unchanged and still requires a real repository Actions secret before `v0.2.0` can be certified.