### PR TITLE
docs: add structured early tester feedback form

### DIFF
--- a/.github/ISSUE_TEMPLATE/early_tester.yml
+++ b/.github/ISSUE_TEMPLATE/early_tester.yml
@@ -1,0 +1,82 @@
+name: Early tester feedback
+description: Report a genuine first-run test with or without a provider API key.
+title: "[Early test]: "
+labels:
+  - help wanted
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for testing Personal AI OS. Do not include API keys, `.env` contents, authorization headers, cookies, private conversations, runtime databases, or unsanitized logs.
+
+        You can contribute useful evidence without a paid provider API key by running:
+        `python scripts/release-provider-smoke.py --provider openai --no-key-only`
+  - type: dropdown
+    id: path
+    attributes:
+      label: Test path
+      description: Which first-run path did you test?
+      options:
+        - Path A — no API key / zero-cost readiness
+        - Path B — provider connection and first chat
+    validations:
+      required: true
+  - type: input
+    id: commit
+    attributes:
+      label: Version or commit
+      placeholder: main commit SHA or v0.2.0
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11, macOS 15, Ubuntu 24.04, etc.
+    validations:
+      required: true
+  - type: input
+    id: runtimes
+    attributes:
+      label: Runtime versions
+      description: Include Python and Node/pnpm when relevant.
+      placeholder: Python 3.12.13; Node 24; pnpm 11.16.0
+    validations:
+      required: true
+  - type: dropdown
+    id: result
+    attributes:
+      label: Overall result
+      options:
+        - Passed as expected
+        - Passed with confusing or rough steps
+        - Failed with a reproducible problem
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: What did you test?
+      description: Briefly list the steps you completed and where any friction appeared.
+      placeholder: "1. Fresh clone...\n2. Installed dependencies...\n3. Ran no-key smoke...\n4. Opened Settings..."
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback or reproducible problem
+      description: Describe anything confusing, broken, unexpectedly difficult, or especially clear.
+    validations:
+      required: true
+  - type: textarea
+    id: sanitized_evidence
+    attributes:
+      label: Sanitized evidence (optional)
+      description: Add only excerpts or screenshots that contain no credentials or private user data.
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed credentials, private conversations, runtime databases, cookies, authorization headers, and other private data from this report.
+          required: true


### PR DESCRIPTION
## Why

The project now supports a zero-cost no-key first-run validation path, but external testers still need a low-friction way to submit useful, privacy-safe evidence.

## What changed

- add a dedicated `Early tester feedback` GitHub Issue form
- let testers identify Path A (no API key) or Path B (full provider / first chat)
- collect OS/runtime/version and reproducible steps in a consistent format
- require a privacy acknowledgement before submission
- keep credentials and private runtime data explicitly out of reports

This does not fabricate adoption or create synthetic feedback; it only makes genuine external feedback easier to submit.