### PR TITLE
security: harden open-source maintenance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default ownership for review and maintenance.
+* @sui-ni2
+
+# Security-sensitive and release-sensitive surfaces.
+/.github/workflows/ @sui-ni2
+/.github/dependabot.yml @sui-ni2
+/SECURITY.md @sui-ni2
+/apps/api/src/personal_ai_os/auth.py @sui-ni2
+/apps/api/src/personal_ai_os/config.py @sui-ni2
+/packages/providers/ @sui-ni2
+/packages/mcp/ @sui-ni2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/packages/core"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/packages/providers"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/packages/mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/packages/projects"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,8 +13,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/apps/api"
@@ -24,8 +20,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/packages/core"
@@ -33,8 +27,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/packages/providers"
@@ -42,8 +34,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/packages/mcp"
@@ -51,8 +41,6 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/packages/projects"
@@ -60,5 +48,3 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 2"
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,14 +10,16 @@ multi-version support policy will be published with the first stable release.
 Do not report vulnerabilities that contain credentials, private user data, exploit
 details, or sensitive deployment information in a public issue.
 
-After the public GitHub repository is created, use GitHub's private vulnerability
-reporting or a private security advisory. If private reporting is not yet enabled,
-contact the maintainer through the public GitHub profile without including sensitive
-details and request a private channel.
+GitHub private vulnerability reporting is not currently enabled for this repository.
+Until it is enabled, contact the maintainer through the public GitHub profile without
+including sensitive details and request a private channel. Do not paste a proof of
+concept, credential, private conversation, deployment secret, or sensitive log into a
+public issue or discussion.
 
 Include the affected version or commit, impact, reproduction conditions, and a minimal
-proof of concept with all secrets and personal data removed. Please allow reasonable
-time for confirmation and remediation before public disclosure.
+proof of concept only after a private reporting channel is established, with all secrets
+and personal data removed. Please allow reasonable time for confirmation and remediation
+before public disclosure.
 
 ## Security boundaries
 


### PR DESCRIPTION
## Why

Personal AI OS is now public and actively seeking external testers/contributors. The repository should continuously scan its code and dependencies, make ownership explicit, and keep its vulnerability-reporting instructions aligned with the repository's actual security settings.

## What changed

- add weekly Dependabot checks for the pnpm workspace, GitHub Actions, and each Python package
- add CodeQL v4 analysis for Python and JavaScript/TypeScript on PRs, main pushes, and a weekly schedule
- add CODEOWNERS for default and security-sensitive surfaces
- correct `SECURITY.md`: private vulnerability reporting is currently disabled, so the policy no longer implies that a private GitHub reporting channel is already available

## Safety

- no provider/API credentials are required
- no billable model calls are introduced
- no runtime/private data is touched
- existing functional CI and real-provider release gate remain unchanged

Merge only after the normal backend/frontend/no-key readiness checks and the new CodeQL jobs pass.