### PR TITLE
chore: monitor Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "pip"
     directory: "/apps/api"
     schedule:


### PR DESCRIPTION
## Why

The repository now has Dependabot coverage for JavaScript, Python packages, and GitHub Actions, but the production Dockerfile still depends on upstream Node and Python base images.

## Change

Add weekly Docker ecosystem checks at the repository root so Dependabot can surface base-image updates for `node:22-bookworm-slim` and `python:3.12-slim`.

No runtime behavior, credentials, or release criteria are changed.