### PR TITLE
chore: make dependency policy fail-closed and deliberate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/apps/api"

--- a/docs/repository-admin-checklist.md
+++ b/docs/repository-admin-checklist.md
@@ -31,6 +31,14 @@ Target policy:
 
 This is a real gap today: an administrator can currently write directly to `main`, so the project process is stronger than the repository enforcement.
 
+## Security analysis settings
+
+Enable the repository **Dependency graph** before adding the Dependency Review workflow. A real trial of `actions/dependency-review-action@v5` failed closed because GitHub reported that Dependency Review is not supported while the graph is disabled. Once the graph is enabled, add the pull-request Dependency Review gate back and fail on newly introduced `high` or `critical` vulnerabilities.
+
+GitHub private vulnerability reporting is also currently disabled. Enable it when possible, then update `SECURITY.md` to point reporters directly to the private reporting flow instead of asking them to establish a private channel first.
+
+CodeQL is already configured in source control for Python and JavaScript/TypeScript. Dependabot version updates are also configured; production Docker runtime **major** jumps remain deliberate compatibility work rather than automatic version-update PRs.
+
 ## Discussions
 
 Enable GitHub Discussions when there is enough external traffic to justify a lower-friction Q&A/ideas channel. Keep reproducible bugs and release blockers in Issues so they remain actionable.


### PR DESCRIPTION
## Why

Dependabot is active, but two repository-level facts need to be encoded honestly:

1. production Docker runtime major upgrades should be deliberate compatibility work, not automatic version-update PRs;
2. GitHub Dependency Review cannot be enabled yet because the repository Dependency graph is currently disabled.

## What changed

- keep weekly Docker update checks but ignore automatic **major-version** jumps for the `node` and `python` base images; patch/minor version maintenance and security updates remain eligible
- document the Dependency graph prerequisite in `docs/repository-admin-checklist.md`
- document that private vulnerability reporting is also currently disabled

## Trial result

A real `actions/dependency-review-action@v5` workflow was tested and failed closed with GitHub's explicit message that Dependency Review is unsupported until the repository Dependency graph is enabled. The workflow was removed rather than merging a permanently red or silently bypassed gate.

PRs #28 (Python 3.12→3.14) and #29 (Node 22→26) were closed as deliberate runtime-major migrations rather than routine maintenance.

This branch was rebuilt from the current `main` after the GitHub Actions runtime upgrades, so it must pass the current CI and CodeQL gates before merge.