### PR TITLE
ci: validate Windows and production container readiness

### DIFF
--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -1,0 +1,81 @@
+name: Platform Readiness
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "requirements-*.txt"
+      - "apps/**"
+      - "packages/**"
+      - "scripts/release-provider-smoke.py"
+      - ".github/workflows/platform-readiness.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "requirements-*.txt"
+      - "apps/**"
+      - "packages/**"
+      - "scripts/release-provider-smoke.py"
+      - ".github/workflows/platform-readiness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-no-key:
+    name: Windows no-key readiness
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Verify fresh no-key readiness on Windows
+        run: python scripts/release-provider-smoke.py --provider openai --no-key-only
+
+  container:
+    name: Container build and health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Build production image
+        run: docker build --tag personal-ai-os:ci .
+      - name: Start production image and verify health
+        shell: bash
+        run: |
+          docker run -d \
+            --name personal-ai-os-ci \
+            -p 127.0.0.1:18080:8080 \
+            -e PERSONAL_AI_OS_REQUIRE_AUTH=false \
+            personal-ai-os:ci
+
+          for attempt in $(seq 1 40); do
+            if curl --fail --silent --show-error http://127.0.0.1:18080/health; then
+              echo
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Container did not become healthy" >&2
+          docker logs personal-ai-os-ci >&2 || true
+          exit 1
+      - name: Clean up container
+        if: always()
+        run: docker rm -f personal-ai-os-ci >/dev/null 2>&1 || true


### PR DESCRIPTION
## Why

Personal AI OS is Windows-first and ships a production Dockerfile, but the existing CI primarily proves Linux source/test/build behavior. Two additional release-readiness claims should be executable rather than documentary.

## What changed

- run the existing fail-closed no-key startup smoke on a real `windows-latest` GitHub runner with Python 3.12
- build the production Docker image from the repository Dockerfile
- start that built image without provider credentials and require its `/health` endpoint to become reachable
- scope this workflow to changes that can affect platform/container readiness, plus manual dispatch

## Safety / cost

- no OpenAI or Anthropic credentials are used
- no billable provider/model call is made
- temporary Windows smoke data is isolated and deleted by the existing smoke runner
- the test container is removed even when the health check fails

This does not replace the real-provider `v0.2.0` release gate or the external Windows tester task in Issue #15.