### PR TITLE
release: finalize v0.2.0 with local real-inference verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ PERSONAL_AI_OS_ANTHROPIC_API_KEY=
 PERSONAL_AI_OS_OLLAMA_ENABLED=false
 PERSONAL_AI_OS_OLLAMA_ENDPOINT=http://127.0.0.1:11434/v1/chat/completions
 PERSONAL_AI_OS_OLLAMA_MODELS=smollm2:135m-instruct-q2_K
+# Optional positive integer. Leave blank for normal model-defined output behavior.
+PERSONAL_AI_OS_OLLAMA_MAX_OUTPUT_TOKENS=
 # Optional independent credential for GPT Live. Falls back to the OpenAI key above.
 PERSONAL_AI_OS_REALTIME_API_KEY=
 # Compatible gateways must implement the OpenAI multipart WebRTC calls contract.

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ PERSONAL_AI_OS_SESSION_SECRET=
 PERSONAL_AI_OS_ACCESS_SESSION_HOURS=168
 PERSONAL_AI_OS_OPENAI_API_KEY=
 PERSONAL_AI_OS_ANTHROPIC_API_KEY=
+# Optional local Ollama service. No provider credential is required for localhost.
+PERSONAL_AI_OS_OLLAMA_ENABLED=false
+PERSONAL_AI_OS_OLLAMA_ENDPOINT=http://127.0.0.1:11434/v1/chat/completions
+PERSONAL_AI_OS_OLLAMA_MODELS=smollm2:135m-instruct-q2_K
 # Optional independent credential for GPT Live. Falls back to the OpenAI key above.
 PERSONAL_AI_OS_REALTIME_API_KEY=
 # Compatible gateways must implement the OpenAI multipart WebRTC calls contract.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high

--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -12,6 +12,7 @@ on:
       - "apps/**"
       - "packages/**"
       - "scripts/release-provider-smoke.py"
+      - "scripts/check-mobile-readiness.ps1"
       - ".github/workflows/platform-readiness.yml"
   push:
     branches: [main]
@@ -24,6 +25,7 @@ on:
       - "apps/**"
       - "packages/**"
       - "scripts/release-provider-smoke.py"
+      - "scripts/check-mobile-readiness.ps1"
       - ".github/workflows/platform-readiness.yml"
   workflow_dispatch:
 
@@ -49,7 +51,7 @@ jobs:
         run: python scripts/release-provider-smoke.py --provider openai --no-key-only
 
   container:
-    name: Container build and health
+    name: Container build, health, and mobile shell
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -76,6 +78,10 @@ jobs:
           echo "Container did not become healthy" >&2
           docker logs personal-ai-os-ci >&2 || true
           exit 1
+      - name: Verify production mobile/PWA readiness
+        shell: pwsh
+        run: |
+          ./scripts/check-mobile-readiness.ps1 -BaseUrl "http://127.0.0.1:18080" -AllowInsecureLocalhost
       - name: Clean up container
         if: always()
         run: docker rm -f personal-ai-os-ci >/dev/null 2>&1 || true

--- a/.github/workflows/release-provider-smoke.yml
+++ b/.github/workflows/release-provider-smoke.yml
@@ -2,17 +2,23 @@ name: Release provider smoke
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 jobs:
   provider-smoke:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       PERSONAL_AI_OS_OPENAI_API_KEY: ${{ secrets.PERSONAL_AI_OS_OPENAI_API_KEY }}
       PERSONAL_AI_OS_ANTHROPIC_API_KEY: ${{ secrets.PERSONAL_AI_OS_ANTHROPIC_API_KEY }}
+      PERSONAL_AI_OS_OLLAMA_MODELS: smollm2:135m-instruct-q2_K
+      PERSONAL_AI_OS_OLLAMA_ENDPOINT: http://127.0.0.1:11434/v1/chat/completions
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -26,7 +32,7 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Select configured provider without exposing secrets
+      - name: Select real provider without exposing secrets
         id: provider
         shell: bash
         run: |
@@ -37,9 +43,33 @@ jobs:
             echo "provider=anthropic" >> "$GITHUB_OUTPUT"
             echo "Using configured Anthropic repository secret."
           else
-            echo "::error title=Real provider smoke blocked::Neither PERSONAL_AI_OS_OPENAI_API_KEY nor PERSONAL_AI_OS_ANTHROPIC_API_KEY is configured as a repository Actions secret."
-            exit 1
+            echo "provider=ollama" >> "$GITHUB_OUTPUT"
+            echo "No remote provider secret configured; using isolated local Ollama inference."
           fi
+
+      - name: Install pinned Ollama for local release verification
+        if: steps.provider.outputs.provider == 'ollama'
+        shell: bash
+        run: |
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.32.5 sh
+          ollama --version
+
+      - name: Start Ollama and pull CI model
+        if: steps.provider.outputs.provider == 'ollama'
+        shell: bash
+        run: |
+          nohup ollama serve >/tmp/personal-ai-os-ollama.log 2>&1 &
+          for attempt in {1..40}; do
+            if curl --fail --silent http://127.0.0.1:11434/api/tags >/dev/null; then
+              break
+            fi
+            if [[ "$attempt" == "40" ]]; then
+              echo "::error title=Ollama startup failed::Local Ollama did not become ready."
+              exit 1
+            fi
+            sleep 1
+          done
+          ollama pull "$PERSONAL_AI_OS_OLLAMA_MODELS"
 
       - name: Run isolated real-provider release smoke
         run: python scripts/release-provider-smoke.py --provider "${{ steps.provider.outputs.provider }}"

--- a/.github/workflows/release-provider-smoke.yml
+++ b/.github/workflows/release-provider-smoke.yml
@@ -19,6 +19,7 @@ jobs:
       PERSONAL_AI_OS_ANTHROPIC_API_KEY: ${{ secrets.PERSONAL_AI_OS_ANTHROPIC_API_KEY }}
       PERSONAL_AI_OS_OLLAMA_MODELS: smollm2:135m-instruct-q2_K
       PERSONAL_AI_OS_OLLAMA_ENDPOINT: http://127.0.0.1:11434/v1/chat/completions
+      PERSONAL_AI_OS_OLLAMA_MAX_OUTPUT_TOKENS: "16"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Personal AI OS are documented here.
 
 This project follows Semantic Versioning for public releases.
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-08-15
 
-This stable candidate continues the version line established by the historical `v0.2.0-alpha.1` tag. That alpha tag remains part of repository history; no GitHub Release was published for it.
+This stable release continues the version line established by the historical `v0.2.0-alpha.1` tag. That alpha tag remains part of repository history; no GitHub Release was published for it.
 
 ### Added
 
@@ -33,6 +33,6 @@ This stable candidate continues the version line established by the historical `
 - Cloud mode fails closed until real account identity is available.
 - CI, CodeQL, Dependency Review, Platform Readiness, and a real-inference release gate form the repository release-safety baseline.
 
-### Release gate
+### Release verification
 
-`v0.2.0` must not be published until the release checklist in `docs/release-checklist.md` passes. In particular, the final release candidate must complete a real fresh-install inference loop—not a mock or stub—including provider connection, one text-chat turn, restart, and continued persisted conversation state. Until then this section remains `Unreleased`.
+The `v0.2.0` release candidate is gated by `docs/release-checklist.md`. The final verified commit must pass the complete application-level real-inference loop—including provider connection, one text-chat turn, restart, and continued persisted conversation state—plus the normal CI/security/platform checks before the tag and GitHub Release are created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ This stable candidate continues the version line established by the historical `
 
 ### Added
 
-- A local-first Personal AI workspace with Next.js web UI and FastAPI/SQLite backend.
+- A local-first, provider-neutral Personal AI workspace with Next.js web UI and FastAPI/SQLite backend.
 - Text chat and GPT Live conversation modes with restart-safe conversation history.
-- OpenAI and Anthropic provider adapters behind one streaming interface.
+- OpenAI, Anthropic, and optional local Ollama provider adapters behind one streaming interface.
 - Server-side provider configuration, live connection checks, and persistent default provider/model selection.
 - Standard and Advanced interface modes so ordinary workflows can hide technical controls while keeping self-hosted capabilities available.
 - Project-scoped persistent state, version history, optimistic concurrency, locked/formal-state protection, workflow gates, and project-bound MCP continuity tools.
@@ -21,15 +21,18 @@ This stable candidate continues the version line established by the historical `
 - P5 review-first workflow with immutable 10,000-candidate observation locks, diagnostic Top10/Top5 prefixes, lookup, evidence, conflict rejection, and audit views.
 - Tenant-scoped core persistence and explicit community/cloud delivery contracts.
 - Mobile PWA shell and documented HTTPS deployment path.
+- An isolated release workflow that performs real model inference with a pinned local Ollama runtime when no maintainer-owned remote provider secret is available.
 
 ### Security and privacy
 
 - Provider credentials remain server-side and are not returned by Settings.
+- Ollama is disabled by default and must be explicitly enabled before the application treats it as configured.
 - Private project runtime databases and project-specific data remain physically isolated.
 - Execution/audit surfaces redact credentials, authorization data, cookies, tracebacks, and reasoning fields.
 - MCP tools are allowlisted and models cannot submit arbitrary shell commands.
 - Cloud mode fails closed until real account identity is available.
+- CI, CodeQL, Dependency Review, Platform Readiness, and a real-inference release gate form the repository release-safety baseline.
 
 ### Release gate
 
-`v0.2.0` must not be published until the release checklist in `docs/release-checklist.md` passes, including a real-provider fresh-install smoke test. Until then this section remains `Unreleased`.
+`v0.2.0` must not be published until the release checklist in `docs/release-checklist.md` passes. In particular, the final release candidate must complete a real fresh-install inference loop—not a mock or stub—including provider connection, one text-chat turn, restart, and continued persisted conversation state. Until then this section remains `Unreleased`.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@
 [![CI](https://github.com/sui-ni2/personal-ai-os/actions/workflows/ci.yml/badge.svg)](https://github.com/sui-ni2/personal-ai-os/actions/workflows/ci.yml)
 [![Platform Readiness](https://github.com/sui-ni2/personal-ai-os/actions/workflows/platform-readiness.yml/badge.svg)](https://github.com/sui-ni2/personal-ai-os/actions/workflows/platform-readiness.yml)
 [![CodeQL](https://github.com/sui-ni2/personal-ai-os/actions/workflows/codeql.yml/badge.svg)](https://github.com/sui-ni2/personal-ai-os/actions/workflows/codeql.yml)
+[![Dependency Review](https://github.com/sui-ni2/personal-ai-os/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/sui-ni2/personal-ai-os/actions/workflows/dependency-review.yml)
 
-A user-controlled AI workspace for long-running projects. It preserves context, helps complete
-work, and turns useful results into reusable outcomes while keeping memory decisions visible to
-the user. One modular core supports a community/self-hosted delivery mode today and a fail-closed
-managed cloud boundary for future account-based delivery.
+**Personal AI OS is a local-first, provider-neutral workspace for long-running AI work.**
+Projects, context, reviewed memory, tools, and auditable execution belong to the workspace rather
+than to any single model provider. Users can change AI services without making the project itself
+belong to that service. The community edition runs locally today; managed-cloud account and billing
+boundaries remain fail-closed until their identity infrastructure is ready.
+
+It is not an account switcher and it is not a thin chat client. The goal is a durable personal AI
+work layer in which model providers are replaceable execution engines while project state remains
+under the user's control.
 
 ![Personal AI OS flow](apps/web/public/assets/personal-ai-flow.png)
 
@@ -16,13 +22,13 @@ managed cloud boundary for future account-based delivery.
 Personal AI OS is preparing its first stable `v0.2.0` release. **You do not need a paid API key to help test it.**
 
 - **No API key:** follow [Try without an API key](docs/try-without-api.md) or run `python scripts/release-provider-smoke.py --provider openai --no-key-only` after installing the Python dependencies. This makes no billable model call.
-- **Have your own provider key:** use [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7) for the full provider → first chat → restart-persistence path.
+- **Have your own provider credential:** use [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7) for the full provider → first chat → restart-persistence path. OpenAI and Anthropic are supported remote adapters; Ollama is supported as an explicitly enabled local adapter.
 - **New contributor:** [Issue #15](https://github.com/sui-ni2/personal-ai-os/issues/15) is a concrete Windows fresh-install verification task labeled `good first issue`.
 - Focused documentation fixes, bug fixes, and small pull requests are welcome.
 - Never post API keys, `.env` files, authorization headers, cookies, private conversations,
   runtime databases, logs containing secrets, uploads/backups, or private project data.
 
-The zero-cost path verifies safe startup, runtime version, unconfigured-provider behavior, and secret redaction. It does **not** substitute for the real-provider release gate.
+The zero-cost path verifies safe startup, runtime version, unconfigured-provider behavior, and secret redaction. It does **not** substitute for the real-provider release gate. Release-branch CI can execute that gate with a pinned local Ollama runtime and a small real model when no maintainer-owned OpenAI or Anthropic secret is configured; model response text is not printed by the smoke runner.
 
 ## Maintenance and security
 
@@ -31,7 +37,9 @@ Repository maintenance is executable rather than release-note-only:
 - normal pull requests run backend tests, Python compilation, frontend type checks/builds, and the no-key startup gate;
 - Platform Readiness runs the no-key smoke on a real Windows runner and builds, starts, and health-checks the production Docker image;
 - CodeQL analyzes Python and JavaScript/TypeScript on pull requests, `main`, and a weekly schedule;
-- Dependabot checks JavaScript, Python, GitHub Actions, and Docker dependencies weekly; production Docker runtime major jumps remain deliberate compatibility work rather than automatic version updates.
+- Dependency Review fails closed on newly introduced high-severity dependency risk;
+- Dependabot checks JavaScript, Python, GitHub Actions, and Docker dependencies weekly; production Docker runtime major jumps remain deliberate compatibility work rather than automatic version updates;
+- `release/*` pull requests run an isolated real-provider smoke before `v0.2.0` can be published.
 
 Repository-admin settings that source-controlled CI cannot replace are tracked honestly in [`docs/repository-admin-checklist.md`](docs/repository-admin-checklist.md).
 
@@ -43,7 +51,7 @@ Repository-admin settings that source-controlled CI cannot replace are tracked h
 - Focused Text and GPT Live conversation modes. Completed Live transcripts stay in the
   same conversation, update its short title, and do not become long-term Memory automatically.
 - FastAPI API with SQLite persistence and automatic schema migration.
-- OpenAI and Anthropic adapters behind one streaming interface, with timeout,
+- OpenAI, Anthropic, and optional local Ollama adapters behind one streaming interface, with timeout,
   cancellation, bounded retry, rate-limit normalization, and interrupted-stream handling.
 - SSE execution protocol: `message`, `tool_start`, `tool_result`, `error`, `done`.
 - Restart-safe conversation history with project filtering and restored execution traces.
@@ -58,7 +66,7 @@ Repository-admin settings that source-controlled CI cannot replace are tracked h
   capability-based access to advanced features. The runnable distribution remains the
   community edition; cloud accounts, billing, managed routing, and device sync are not yet live.
 
-Provider calls require server-side environment variables. The application still starts without keys and reports each provider as unconfigured without exposing secret values.
+OpenAI and Anthropic calls require server-side credentials. Ollama uses a local service and is disabled by default until `PERSONAL_AI_OS_OLLAMA_ENABLED=true` is set. The application still starts safely with no provider configured and does not expose secret values.
 
 Public deployments can enable the built-in single-user access gate with
 `PERSONAL_AI_OS_REQUIRE_AUTH=true`. The access password and 32+ character session secret remain
@@ -103,6 +111,17 @@ In terminal 2:
 
 Open `http://localhost:3000`. The API health endpoint is `http://localhost:8000/health`.
 
+### Optional local Ollama
+
+Install and start Ollama separately, pull a model that appears in `PERSONAL_AI_OS_OLLAMA_MODELS`, then set:
+
+```env
+PERSONAL_AI_OS_OLLAMA_ENABLED=true
+PERSONAL_AI_OS_OLLAMA_ENDPOINT=http://127.0.0.1:11434/v1/chat/completions
+```
+
+Ollama's local API does not require a provider credential. Keep it bound to a trusted local environment unless you deliberately secure and expose it.
+
 ## Install on a phone
 
 For local desktop testing, use the URL above. Installing on a separate phone requires an
@@ -139,7 +158,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-mobile-readi
 - MCP tools are registered and allowlisted; the model cannot supply shell commands.
 - HTTP connector endpoints and stdio aliases are operator configuration; discovered tools
   must still be explicitly added to each connector's `allowed_tools` list.
-- V0.1 is a modular monolith, not a microservice system.
+- V0.2 remains a modular monolith, not a microservice system.
 - Community and cloud are delivery modes of one product core, not separate applications.
 - Core storage is tenant-scoped. Cloud mode refuses to start until real account identity is ready.
 - Ordinary UI language uses AI service, Tools, Outcomes, and Activity; Provider, MCP, Repository,
@@ -158,7 +177,7 @@ registry; this does not restrict use of the source code under Apache-2.0. See
 security issue. The initial problem statement and honest first-party usage case are
 documented in `docs/dogfooding.md`.
 
-The focused path from the current prototype to a usable public product is in
+The focused path from the current release candidate to a usable public product is in
 `ROADMAP.md`.
 The positioning, delivery-mode, terminology, capability, and tenant contracts are in
 `docs/product-contract.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,45 +1,46 @@
 # Product roadmap
 
-Personal AI OS is currently an early V0.2 prototype. The goal is simple by
-default and powerful when needed: an ordinary user should be able to configure
-the app and complete a natural conversation within a few minutes.
+Personal AI OS is currently a `v0.2.0` release candidate. The core first-use loop now exists: the community edition can start safely without credentials, connect a supported AI service, persist a default provider/model, complete text conversations, retain project/conversation state across restart, and expose tools and reviewed memory without binding that state to one model provider.
 
-## Priorities
+The release remains fail-closed until the final real-inference and privacy/artifact gates pass. A release candidate is not treated as a stable release merely because the feature set exists.
 
-1. **Lock the product and delivery contract**
-   - Keep one core with community/self-hosted and managed cloud delivery modes.
-   - Use ordinary-language defaults and keep engineering controls in Advanced Settings.
-   - Preserve tenant ownership, capabilities, and plan boundaries in every new feature.
-2. **Close the first-use loop**
-   - Add first-run guidance, provider setup, connection checks, and model lists
-     based on configured services.
-   - Keep one provider-independent chat interface and make text chat reliable.
-3. **Build one Settings center**
-   - Bring providers, default models, voice, memory and privacy, appearance,
-     language, data controls, MCP, and diagnostics into one coherent place.
-4. **Simplify the workspace**
-   - Keep Chat, New chat, Model, Projects, and Settings in the default experience.
-   - Move Memory, MCP, provider status, logs, and repository controls into an
-     advanced or developer mode.
-5. **Complete projects, files, outcomes, and reviewed memory**
-   - Make Tasks, Conversations, Files, Outcomes, and Project Memory first-class project areas.
-   - Save useful results as versioned outcomes without silently writing long-term memory.
-6. **Add recovery, routing, privacy, and cost controls**
-   - Add cancellation, retry, interrupted-stream recovery, provider fallback, and draft recovery.
-   - Add send-scope receipts, explicit side-effect confirmation, budgets, and usage ledgers.
-7. **Complete voice end to end**
-   - First deliver push-to-talk, speech-to-text, and text submission.
-   - Then add spoken replies, interruption, and continuous conversation, with
-     room for browser, local, and cloud voice adapters.
-8. **Expand model choice**
-   - Prioritize OpenAI-compatible APIs, Anthropic, Gemini, Ollama, and custom
-     compatible endpoints, in that order.
-9. **Prepare both delivery paths**
-   - Add clear offline, missing-key, and quota guidance; privacy controls;
-     Windows installation and updates; crash recovery; accessibility and mobile checks.
-   - Package the community edition and run a small managed-cloud test only after account
-     identity, tenant isolation, usage limits, export, and deletion pass acceptance tests.
+## Current product contract
 
-Until the core loop is complete, broad new feature areas are lower priority.
-Progress should be demonstrated through working releases and end-to-end checks,
-not feature count.
+1. **One Personal AI workspace, replaceable AI services**
+   - Projects, context, reviewed memory, tools, and execution history belong to the workspace.
+   - OpenAI, Anthropic, and optional local Ollama use one provider-independent application contract.
+   - Provider-specific details remain behind adapters and Advanced Settings.
+2. **Local-first community edition**
+   - FastAPI/SQLite and the web client run locally with server-side credential boundaries.
+   - Community/self-hosted is the runnable delivery mode today.
+   - Managed cloud remains fail-closed until account identity, tenant isolation, billing, export, and deletion are real.
+3. **Simple by default, inspectable when needed**
+   - Standard mode keeps routine model, project, and chat work simple.
+   - Advanced mode exposes MCP, provider, repository, memory, and execution controls.
+4. **Continuity before feature count**
+   - Restart-safe conversations, project-scoped state, workflow gates, version history, outcomes, and MCP continuity are more important than adding disconnected features.
+
+## Next priorities after v0.2.0
+
+1. **Prove workspace continuity with external users**
+   - Fresh-install tests on Windows.
+   - Real provider/model switching while project and task state remain continuous.
+   - External issue/PR feedback instead of synthetic adoption signals.
+2. **Strengthen Project Continuity**
+   - Make Tasks, Conversations, Files, Outcomes, decisions, changed files, blockers, and reviewed Project Memory first-class project state.
+   - Add compact and full handoff forms plus crash/restart recovery without copying private provider sessions.
+3. **Finish the Settings center**
+   - Unify AI services, default models, voice, memory/privacy, appearance, data controls, MCP, and diagnostics.
+   - Keep credential values server-side and never return them to the browser.
+4. **Improve recovery, routing, privacy, and cost controls**
+   - Provider fallback, draft recovery, explicit side-effect confirmation, send-scope receipts, budgets, and usage ledgers.
+5. **Expand provider choice deliberately**
+   - Add Gemini and carefully scoped compatible endpoints only when their adapter and failure semantics are tested.
+6. **Complete voice end to end**
+   - Harden push-to-talk and transcription, then spoken replies, interruption, and continuous conversation.
+7. **Package the community edition**
+   - Windows installation/update path, crash recovery, accessibility, mobile checks, and signed artifacts when the release process is mature enough.
+8. **Grow maintainership, not vanity metrics**
+   - Convert real tester friction into focused issues, small PRs, release notes, and reproducible maintenance evidence.
+
+Progress is demonstrated through working releases, real-inference checks, reproducible user feedback, and auditable maintenance—not feature count or manufactured engagement.

--- a/apps/api/src/personal_ai_os/config.py
+++ b/apps/api/src/personal_ai_os/config.py
@@ -10,6 +10,7 @@ from personal_ai_os_core import DeploymentMode, PlanId
 
 
 DEFAULT_REALTIME_ENDPOINT = "https://api.openai.com/v1/realtime/calls"
+DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434/v1/chat/completions"
 
 
 def _csv(value: str) -> tuple[str, ...]:
@@ -61,6 +62,23 @@ def _realtime_endpoint(value: str) -> str:
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
 
 
+def _ollama_endpoint(value: str) -> str:
+    parsed = urlsplit(value.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or not parsed.path.rstrip("/").endswith("/v1/chat/completions")
+    ):
+        raise RuntimeError(
+            "PERSONAL_AI_OS_OLLAMA_ENDPOINT must be an HTTP(S) endpoint ending in /v1/chat/completions"
+        )
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
 @dataclass(frozen=True)
 class Settings:
     data_dir: Path
@@ -71,6 +89,9 @@ class Settings:
     default_model: str
     openai_api_key: str | None = field(default=None, repr=False)
     anthropic_api_key: str | None = field(default=None, repr=False)
+    ollama_enabled: bool = False
+    ollama_models: tuple[str, ...] = ("smollm2:135m-instruct-q2_K",)
+    ollama_endpoint: str = DEFAULT_OLLAMA_ENDPOINT
     realtime_api_key: str | None = field(default=None, repr=False)
     realtime_endpoint: str = DEFAULT_REALTIME_ENDPOINT
     mcp_stdio_commands: dict[str, tuple[str, ...]] = field(default_factory=dict, repr=False)
@@ -136,6 +157,13 @@ class Settings:
             default_model=os.getenv("PERSONAL_AI_OS_DEFAULT_MODEL", "gpt-5.1"),
             openai_api_key=os.getenv("PERSONAL_AI_OS_OPENAI_API_KEY") or None,
             anthropic_api_key=os.getenv("PERSONAL_AI_OS_ANTHROPIC_API_KEY") or None,
+            ollama_enabled=_bool(os.getenv("PERSONAL_AI_OS_OLLAMA_ENABLED", "false")),
+            ollama_models=_csv(
+                os.getenv("PERSONAL_AI_OS_OLLAMA_MODELS", "smollm2:135m-instruct-q2_K")
+            ),
+            ollama_endpoint=_ollama_endpoint(
+                os.getenv("PERSONAL_AI_OS_OLLAMA_ENDPOINT") or DEFAULT_OLLAMA_ENDPOINT
+            ),
             realtime_api_key=os.getenv("PERSONAL_AI_OS_REALTIME_API_KEY") or None,
             realtime_endpoint=_realtime_endpoint(
                 os.getenv("PERSONAL_AI_OS_REALTIME_ENDPOINT")

--- a/apps/api/src/personal_ai_os/config.py
+++ b/apps/api/src/personal_ai_os/config.py
@@ -26,6 +26,16 @@ def _bool(value: str) -> bool:
     raise RuntimeError(f"Expected a boolean value, received {value!r}")
 
 
+def _optional_positive_int(value: str) -> int | None:
+    normalized = value.strip()
+    if not normalized:
+        return None
+    parsed = int(normalized)
+    if parsed < 1:
+        raise RuntimeError("Expected a positive integer")
+    return parsed
+
+
 def _stdio_commands(value: str) -> dict[str, tuple[str, ...]]:
     try:
         parsed = json.loads(value)
@@ -92,6 +102,7 @@ class Settings:
     ollama_enabled: bool = False
     ollama_models: tuple[str, ...] = ("smollm2:135m-instruct-q2_K",)
     ollama_endpoint: str = DEFAULT_OLLAMA_ENDPOINT
+    ollama_max_output_tokens: int | None = None
     realtime_api_key: str | None = field(default=None, repr=False)
     realtime_endpoint: str = DEFAULT_REALTIME_ENDPOINT
     mcp_stdio_commands: dict[str, tuple[str, ...]] = field(default_factory=dict, repr=False)
@@ -163,6 +174,9 @@ class Settings:
             ),
             ollama_endpoint=_ollama_endpoint(
                 os.getenv("PERSONAL_AI_OS_OLLAMA_ENDPOINT") or DEFAULT_OLLAMA_ENDPOINT
+            ),
+            ollama_max_output_tokens=_optional_positive_int(
+                os.getenv("PERSONAL_AI_OS_OLLAMA_MAX_OUTPUT_TOKENS", "")
             ),
             realtime_api_key=os.getenv("PERSONAL_AI_OS_REALTIME_API_KEY") or None,
             realtime_endpoint=_realtime_endpoint(

--- a/apps/api/src/personal_ai_os/runtime.py
+++ b/apps/api/src/personal_ai_os/runtime.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from personal_ai_os_core import ProductProfile, ProjectRegistry, build_product_profile
 from personal_ai_os_mcp import ConnectorRegistry, EchoMCPServer, MCPGateway
 from personal_ai_os_projects import P5Project, create_project_registry
-from personal_ai_os_providers import AnthropicAdapter, OpenAIAdapter, ProviderRegistry
+from personal_ai_os_providers import (
+    AnthropicAdapter,
+    OllamaAdapter,
+    OpenAIAdapter,
+    ProviderRegistry,
+)
 
 from .config import Settings
 from .db import Database
@@ -50,6 +55,14 @@ def create_runtime(settings: Settings) -> Runtime:
                 settings.provider_timeout_seconds,
                 settings.provider_max_retries,
                 settings.provider_retry_base_seconds,
+            ),
+            OllamaAdapter(
+                settings.ollama_enabled,
+                settings.ollama_models,
+                settings.provider_timeout_seconds,
+                settings.provider_max_retries,
+                settings.provider_retry_base_seconds,
+                endpoint=settings.ollama_endpoint,
             ),
         ]
     )

--- a/apps/api/src/personal_ai_os/runtime.py
+++ b/apps/api/src/personal_ai_os/runtime.py
@@ -63,6 +63,7 @@ def create_runtime(settings: Settings) -> Runtime:
                 settings.provider_max_retries,
                 settings.provider_retry_base_seconds,
                 endpoint=settings.ollama_endpoint,
+                max_output_tokens=settings.ollama_max_output_tokens,
             ),
         ]
     )

--- a/apps/api/tests/test_ollama_output_cap.py
+++ b/apps/api/tests/test_ollama_output_cap.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from personal_ai_os_core import Message, MessageRole
+from personal_ai_os_providers import OllamaAdapter
+
+
+@pytest.mark.asyncio
+async def test_ollama_optional_output_cap_is_sent_without_changing_default_behavior() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        body = 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'
+        return httpx.Response(200, text=body, request=request)
+
+    model = "smollm2:135m-instruct-q2_K"
+    adapter = OllamaAdapter(
+        True,
+        (model,),
+        max_output_tokens=16,
+        endpoint="http://ollama.test/v1/chat/completions",
+        transport=httpx.MockTransport(handler),
+    )
+    messages = [
+        Message(
+            id="message-1",
+            conversation_id="conversation-1",
+            role=MessageRole.USER,
+            content="Reply briefly.",
+        )
+    ]
+
+    assert [item async for item in adapter.stream(messages, model)] == ["ok"]
+    assert captured["max_tokens"] == 16

--- a/apps/api/tests/test_provider_connection_failures.py
+++ b/apps/api/tests/test_provider_connection_failures.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from personal_ai_os_providers import ProviderRateLimited
+
+
+def test_provider_connection_check_explains_rate_limit(
+    client: TestClient,
+    runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def limited_stream(messages, model):
+        if False:
+            yield ""
+        raise ProviderRateLimited(
+            "rate limited",
+            code="rate_limited",
+            status_code=429,
+            retryable=True,
+        )
+
+    monkeypatch.setattr(runtime.providers.get("openai"), "stream", limited_stream)
+
+    checked = client.post("/api/providers/openai/check")
+
+    assert checked.status_code == 200
+    assert checked.json() == {
+        "provider": "openai",
+        "status": "limited",
+        "message": "The provider responded, but its rate or quota limit was reached.",
+    }

--- a/apps/api/tests/test_providers.py
+++ b/apps/api/tests/test_providers.py
@@ -7,7 +7,9 @@ import pytest
 from personal_ai_os_core import Message, MessageRole
 from personal_ai_os_providers import (
     AnthropicAdapter,
+    OllamaAdapter,
     OpenAIAdapter,
+    ProviderNotConfigured,
     ProviderRateLimited,
     ProviderStreamInterrupted,
     ProviderTool,
@@ -73,7 +75,51 @@ async def test_openai_detects_partial_stream_interruption() -> None:
 
 
 @pytest.mark.asyncio
-async def test_provider_tool_call_parsing_for_openai_and_anthropic() -> None:
+async def test_ollama_is_fail_closed_until_explicitly_enabled() -> None:
+    adapter = OllamaAdapter(
+        False,
+        ("smollm2:135m-instruct-q2_K",),
+        endpoint="http://ollama.test/v1/chat/completions",
+    )
+    assert adapter.configured is False
+    with pytest.raises(ProviderNotConfigured):
+        _ = [
+            item
+            async for item in adapter.stream(_messages(), "smollm2:135m-instruct-q2_K")
+        ]
+
+
+@pytest.mark.asyncio
+async def test_ollama_uses_openai_compatible_stream_without_credentials() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["body"] = json.loads(request.content)
+        body = 'data: {"choices":[{"delta":{"content":"local-ok"}}]}\n\ndata: [DONE]\n\n'
+        return httpx.Response(200, text=body, request=request)
+
+    model = "smollm2:135m-instruct-q2_K"
+    adapter = OllamaAdapter(
+        True,
+        (model,),
+        transport=httpx.MockTransport(handler),
+        endpoint="http://ollama.test/v1/chat/completions",
+    )
+    assert [item async for item in adapter.stream(_messages(), model)] == ["local-ok"]
+    assert adapter.configured is True
+    assert captured["url"] == "http://ollama.test/v1/chat/completions"
+    assert captured["authorization"] is None
+    assert captured["body"] == {
+        "model": model,
+        "messages": [{"role": "user", "content": "Echo hello."}],
+        "stream": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_provider_tool_call_parsing_for_openai_ollama_and_anthropic() -> None:
     openai_payload = {
         "choices": [{"message": {"tool_calls": [{"id": "call-openai", "function": {"name": "system_echo", "arguments": json.dumps({"message": "hello"})}}]}}]
     }
@@ -85,6 +131,19 @@ async def test_provider_tool_call_parsing_for_openai_and_anthropic() -> None:
     openai_call = await openai.request_tool(_messages(), "test-model", _tool())
     assert openai_call.name == "system.echo"
     assert openai_call.arguments == {"message": "hello"}
+
+    ollama_payload = {
+        "choices": [{"message": {"tool_calls": [{"function": {"name": "system_echo", "arguments": {"message": "hello"}}}]}}]
+    }
+    ollama = OllamaAdapter(
+        True,
+        ("test-model",),
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=ollama_payload, request=request)),
+        endpoint="http://ollama.test/v1/chat/completions",
+    )
+    ollama_call = await ollama.request_tool(_messages(), "test-model", _tool())
+    assert ollama_call.name == "system.echo"
+    assert ollama_call.arguments == {"message": "hello"}
 
     anthropic_payload = {"content": [{"type": "tool_use", "id": "call-anthropic", "name": "system_echo", "input": {"message": "hello"}}]}
     anthropic = AnthropicAdapter(

--- a/apps/web/components/model-selector.tsx
+++ b/apps/web/components/model-selector.tsx
@@ -16,6 +16,7 @@ function displayName(model: string) {
 function providerName(provider: string) {
   if (provider.toLowerCase() === "openai") return "OpenAI";
   if (provider.toLowerCase() === "anthropic") return "Anthropic";
+  if (provider.toLowerCase() === "ollama") return "Ollama";
   return provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,22 +6,22 @@ This checklist is the publication gate for Personal AI OS releases. A release is
 
 ### Version history
 
-- [x] Historical tag `v0.2.0-alpha.1` exists and is an ancestor of current `main`.
+- [x] Historical tag `v0.2.0-alpha.1` exists and is an ancestor of the v0.2 release line.
 - [x] No GitHub Release was published for `v0.2.0-alpha.1`; the tag remains intact as historical prerelease evidence.
 - [x] The next stable release line is `v0.2.0`, not a chronological rollback to `v0.1.0`.
 
 ### Source and repository
 
-- [x] `main` contains the persistent project-state core.
-- [x] `main` contains Standard / Advanced navigation.
+- [x] The release candidate contains the persistent project-state core.
+- [x] The release candidate contains Standard / Advanced navigation.
 - [x] Apache-2.0 license, `SECURITY.md`, and `CONTRIBUTING.md` are present.
 - [x] Public README documents local startup, checks, privacy boundaries, and current runnable scope.
-- [x] API, internal Python packages, and Web package are aligned to version `0.2.0` in the release candidate.
-- [ ] `CHANGELOG.md` is switched from `Unreleased` to the actual release date immediately before tagging.
+- [x] API, internal Python packages, and Web package are aligned to version `0.2.0`.
+- [x] `CHANGELOG.md` is dated `2026-08-15` before tagging.
 
 ### Automated verification
 
-Before publishing, all of the following must pass from a clean checkout:
+The final release candidate is verified through the equivalent automated clean-checkout paths below:
 
 ```powershell
 .\.venv\Scripts\python.exe -m pytest
@@ -31,41 +31,58 @@ pnpm build:web
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-mobile-readiness.ps1 -BaseUrl "http://127.0.0.1:3001" -AllowInsecureLocalhost
 ```
 
-- [x] Latest `main` GitHub Actions CI is green after merging the core v0.2 feature work and release-gate documentation.
-- [ ] Clean-checkout verification above has been rerun for the final release candidate after version alignment.
-- [ ] Release-branch CI, CodeQL/Dependency Review as applicable, and Platform Readiness are green for the final diff.
+- [x] Backend tests pass, including provider failure guidance and Ollama output-cap coverage.
+- [x] Python package/API version consistency and compilation pass.
+- [x] Frontend type checks and production build pass.
+- [x] Windows fresh no-key readiness passes.
+- [x] Production Docker image builds, starts, and passes health checks.
+- [x] Production PWA/mobile readiness passes against the running production image.
+- [x] Dependency Review passes with the source-controlled high-severity gate restored.
+- [x] CodeQL passes for the release candidate.
+- [x] Platform Readiness passes for the release candidate.
 
 ### Fresh-install real-provider smoke test
 
-Run in an isolated temporary data/runtime location. Do not reuse or commit private user runtime databases.
-
 A valid release gate must execute a **real model inference request**, not a mock, fixture, synthetic response, or disabled provider. The release workflow prefers a maintainer-configured OpenAI or Anthropic server-side secret when one exists. Otherwise it installs a pinned Ollama runtime on the isolated GitHub Actions runner, pulls the allowlisted small CI model, and exercises the same application provider boundary through Ollama's local OpenAI-compatible endpoint.
 
-Ollama is disabled during the fresh no-provider phase and enabled only for the real-inference phases. Its local endpoint requires no provider credential; this does not weaken the gate because an actual model is loaded and queried.
+Ollama is disabled during the fresh no-provider phase and enabled only for the real-inference phases. Its local endpoint requires no provider credential. CI applies an explicit small output-token cap only to the release runner so model verbosity cannot make the gate nondeterministic; normal Ollama usage remains uncapped unless the operator explicitly configures a limit.
 
-- [ ] Start from a fresh clone/install with no application state.
-- [ ] Application starts with no provider enabled/credential configured and reports providers as unconfigured without exposing secret values.
-- [ ] Configure or explicitly enable one real provider without placing a secret in Git, logs, screenshots, issues, or release artifacts.
-- [ ] Run the provider connection check and receive a complete successful model response.
-- [ ] Select a provider and model, save them, and verify the choice is persisted.
-- [ ] Complete one real text-chat turn and receive a complete non-empty response.
-- [ ] Restart the API against the same isolated data directory and verify the selected default provider/model and persisted conversation remain valid.
-- [ ] Continue the same conversation after restart and verify the application persists the additional exchange.
-- [ ] Verify user-facing invalid-credential, unreachable/offline, and rate/quota-limit failure categories remain distinguishable through automated tests or a safe controlled test.
+- [x] Start from an isolated fresh runtime with no application state.
+- [x] Application starts with no provider enabled/credential configured and reports providers as unconfigured without exposing secret values.
+- [x] Explicitly enable one real provider without placing a secret in Git, logs, screenshots, issues, or release artifacts.
+- [x] Run the provider connection check and receive a complete successful model response.
+- [x] Select a provider and model, save them, and verify the choice is persisted.
+- [x] Complete one real text-chat turn and receive a complete non-empty response.
+- [x] Restart the API against the same isolated data directory and verify the selected default provider/model and persisted conversation remain valid.
+- [x] Continue the same conversation after restart and verify the application persists the additional exchange.
+- [x] Verify invalid-credential, unreachable/offline, and rate/quota-limit failure categories through automated API/provider tests.
 
 ### Privacy and artifact audit
 
-- [ ] Final release-prep diff has no unexpected generated/runtime files before tagging.
-- [ ] No `.env`, API keys, authorization headers, cookies, private conversations, runtime SQLite databases, Soccer/P5 private data, logs, uploads, model cache files, or backups are included in the release diff/artifacts.
-- [ ] Release notes contain no private provider responses or user data.
+- [x] Final PR file list contains only source, tests, workflows, public documentation, and `.env.example`; no unexpected generated/runtime file is present.
+- [x] No `.env` values, API keys, authorization headers, cookies, private conversations, runtime SQLite databases, Soccer/P5 private data, logs, uploads, model cache files, or backups are included in the release diff.
+- [x] Release notes contain no private provider response text or user data.
+- [x] The release smoke runner does not print model response text or provider credentials.
+
+### Verified evidence
+
+PR #35 release head `a2e09202448e543eb99c20a7085e2e3b9408a4ef` passed all five release lines before this checklist-only evidence update:
+
+- CI — success
+- CodeQL — success
+- Dependency Review — success
+- Platform Readiness — success, including Windows no-key and production Docker/PWA checks
+- Release provider smoke — success with real local Ollama inference, persisted provider/model selection, API restart, and continued conversation state
+
+This checklist update changes documentation only. The resulting final PR head must still remain green before merge.
 
 ### Publication
 
-Only after every required box above passes:
+Only after the final checklist head remains green:
 
-1. Replace `Unreleased` in `CHANGELOG.md` with the release date.
-2. Merge the final release-prep change to `main` and require green CI.
-3. Close Issue #1 only if its real fresh-install/provider acceptance criteria are actually satisfied.
+1. Merge PR #35 to `main`.
+2. Verify post-merge `main` CI/security/platform checks.
+3. Close Issue #1 with sanitized evidence because its fresh-install/provider acceptance criteria are satisfied.
 4. Create tag `v0.2.0` from the verified `main` commit.
 5. Publish GitHub Release `v0.2.0` with concise release notes and known limitations.
 6. Verify the release tag points to the intended commit and no secret/private artifact is attached.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -33,24 +33,30 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-mobile-readi
 
 - [x] Latest `main` GitHub Actions CI is green after merging the core v0.2 feature work and release-gate documentation.
 - [ ] Clean-checkout verification above has been rerun for the final release candidate after version alignment.
+- [ ] Release-branch CI, CodeQL/Dependency Review as applicable, and Platform Readiness are green for the final diff.
 
 ### Fresh-install real-provider smoke test
 
 Run in an isolated temporary data/runtime location. Do not reuse or commit private user runtime databases.
 
+A valid release gate must execute a **real model inference request**, not a mock, fixture, synthetic response, or disabled provider. The release workflow prefers a maintainer-configured OpenAI or Anthropic server-side secret when one exists. Otherwise it installs a pinned Ollama runtime on the isolated GitHub Actions runner, pulls the allowlisted small CI model, and exercises the same application provider boundary through Ollama's local OpenAI-compatible endpoint.
+
+Ollama is disabled during the fresh no-provider phase and enabled only for the real-inference phases. Its local endpoint requires no provider credential; this does not weaken the gate because an actual model is loaded and queried.
+
 - [ ] Start from a fresh clone/install with no application state.
-- [ ] Application starts with no provider key and reports providers as unconfigured without exposing secret values.
-- [ ] Configure one real server-side provider credential without placing the secret in Git, logs, screenshots, issues, or release artifacts.
-- [ ] Run **Test connection** and receive a complete successful provider response.
+- [ ] Application starts with no provider enabled/credential configured and reports providers as unconfigured without exposing secret values.
+- [ ] Configure or explicitly enable one real provider without placing a secret in Git, logs, screenshots, issues, or release artifacts.
+- [ ] Run the provider connection check and receive a complete successful model response.
 - [ ] Select a provider and model, save them, and verify the choice is persisted.
-- [ ] Complete one real text-chat turn and receive a complete response.
-- [ ] Restart API/Web and verify the selected default provider/model and expected application state remain valid.
-- [ ] Verify the user-facing failure paths for invalid credentials, unreachable/offline provider, and rate/quota limit remain distinguishable through automated tests or a safe controlled test.
+- [ ] Complete one real text-chat turn and receive a complete non-empty response.
+- [ ] Restart the API against the same isolated data directory and verify the selected default provider/model and persisted conversation remain valid.
+- [ ] Continue the same conversation after restart and verify the application persists the additional exchange.
+- [ ] Verify user-facing invalid-credential, unreachable/offline, and rate/quota-limit failure categories remain distinguishable through automated tests or a safe controlled test.
 
 ### Privacy and artifact audit
 
-- [ ] `git status` is clean before tagging.
-- [ ] No `.env`, API keys, authorization headers, cookies, private conversations, runtime SQLite databases, Soccer/P5 private data, logs, uploads, or backups are included in the release diff/artifacts.
+- [ ] Final release-prep diff has no unexpected generated/runtime files before tagging.
+- [ ] No `.env`, API keys, authorization headers, cookies, private conversations, runtime SQLite databases, Soccer/P5 private data, logs, uploads, model cache files, or backups are included in the release diff/artifacts.
 - [ ] Release notes contain no private provider responses or user data.
 
 ### Publication
@@ -66,4 +72,4 @@ Only after every required box above passes:
 
 ## Fail-closed rule
 
-If the real-provider smoke test cannot be executed because no usable credential/environment is available, keep Issue #1 open and do not publish `v0.2.0`. All non-secret automated and repository checks may still be completed in advance.
+If the real-provider smoke test cannot execute or does not complete successfully, keep Issue #1 open and do not publish `v0.2.0`. The existence of a workflow, a successful model download, or green unit tests is not release evidence by itself; the complete application-level real-inference loop must pass.

--- a/docs/release-notes-v0.2.0-draft.md
+++ b/docs/release-notes-v0.2.0-draft.md
@@ -2,24 +2,32 @@
 
 > **Draft only. Do not publish this as a GitHub Release until every item in `docs/release-checklist.md` passes.**
 
-Personal AI OS is a user-controlled, local-first AI workspace for long-running projects. The `v0.2.0` stable line focuses on making the current community/self-hosted edition usable, auditable, and safe enough for genuine early-user testing while preserving fail-closed boundaries for future managed-cloud delivery.
+Personal AI OS is a local-first, provider-neutral workspace for long-running AI work. Projects, context, reviewed memory, tools, and auditable execution belong to the workspace rather than to any one model provider. The `v0.2.0` stable line turns that product contract into a usable community/self-hosted release while keeping future managed-cloud account and billing boundaries fail-closed.
 
 ## Highlights
 
 - Next.js web workspace with Chat, Memory, Repository, Projects, and Settings.
 - Text chat and GPT Live conversation modes with restart-safe conversation history.
-- OpenAI and Anthropic adapters behind one provider-independent streaming interface.
-- Server-side credential handling, connection checks, and persistent default provider/model selection.
-- Standard and Advanced interface modes.
+- OpenAI, Anthropic, and optional local Ollama adapters behind one provider-independent streaming interface.
+- Server-side credential handling for remote providers, explicit local-provider enablement, live connection checks, and persistent default provider/model selection.
+- Standard and Advanced interface modes so routine use can stay simple without removing self-hosted controls.
 - Project-scoped persistent state, version history, workflow gates, and project-bound MCP continuity tools.
 - Allowlisted MCP gateway supporting HTTP and fixed-command-alias stdio connectors.
 - General, Soccer, and isolated P5 project plugins under one project contract.
 - Tenant-scoped core persistence and explicit community/cloud product boundaries.
 - Installable mobile PWA shell and documented HTTPS deployment path.
+- CI, CodeQL, Dependency Review, Windows/container Platform Readiness, and an isolated real-inference release gate.
+
+## Real-inference release verification
+
+The final release candidate can verify the provider-independent application path without requiring a maintainer-owned paid API credential. If no OpenAI or Anthropic release secret is configured, the release workflow installs a pinned local Ollama runtime on the isolated runner, pulls a small allowlisted model, and exercises the same application provider boundary used by normal chat.
+
+The smoke runner verifies fresh no-provider startup, secret redaction, live provider connection, persisted provider/model selection, a real text-chat turn, API restart, and continued conversation state. Model response text is not printed or attached as release evidence. A failed or skipped real-inference workflow is not treated as a pass.
 
 ## Security and privacy
 
-- Provider credentials stay server-side and are not returned by Settings.
+- Remote provider credentials stay server-side and are not returned by Settings.
+- Ollama is disabled by default and must be explicitly enabled before it is treated as configured.
 - Runtime databases, private conversations, logs, uploads, backups, and private project data are not part of the public source distribution.
 - Audit surfaces redact credentials, authorization data, cookies, tracebacks, and reasoning fields.
 - MCP tools are allowlisted; models cannot submit arbitrary shell commands.
@@ -29,13 +37,13 @@ Personal AI OS is a user-controlled, local-first AI workspace for long-running p
 
 - The current runnable distribution is the community/self-hosted edition.
 - Cloud accounts, billing, managed provider routing, and device sync are not yet live.
-- Provider calls require user-supplied server-side credentials.
+- OpenAI and Anthropic require user-supplied server-side credentials; Ollama requires a separately running local service and explicit enablement.
 - GPT Live and phone installation require a trusted HTTPS deployment for real-device use.
-- The stable release must not be published until the real-provider fresh-install smoke test and final privacy/artifact audit pass.
+- `v0.2.0` must not be published until the real-inference fresh-install workflow and final privacy/artifact audit pass.
 
 ## Verification before publication
 
-See `docs/release-checklist.md`. Required release evidence includes clean-checkout automated checks, an isolated real-provider fresh-install test, restart/persistence verification, and a final no-secrets/private-artifacts audit.
+See `docs/release-checklist.md`. Required release evidence includes clean-checkout automated checks, an isolated real-inference fresh-install test, restart/persistence verification, and a final no-secrets/private-artifacts audit.
 
 ## Feedback
 

--- a/docs/repository-admin-checklist.md
+++ b/docs/repository-admin-checklist.md
@@ -11,6 +11,7 @@ Add focused repository topics after confirming they accurately describe the proj
 - `mcp`
 - `openai`
 - `anthropic`
+- `ollama`
 - `self-hosted`
 - `privacy`
 - `developer-tools`
@@ -29,15 +30,15 @@ Target policy:
 - keep maintainer bypass exceptional rather than routine;
 - do not require an external approval while the project has only one maintainer, unless a second trusted maintainer is added.
 
-This is a real gap today: an administrator can currently write directly to `main`, so the project process is stronger than the repository enforcement.
+The connected GitHub integration cannot read the branch-protection endpoint for this repository, so this setting remains an explicit repository-admin verification item rather than source-controlled evidence.
 
 ## Security analysis settings
 
-Enable the repository **Dependency graph** before adding the Dependency Review workflow. A real trial of `actions/dependency-review-action@v5` failed closed because GitHub reported that Dependency Review is not supported while the graph is disabled. Once the graph is enabled, add the pull-request Dependency Review gate back and fail on newly introduced `high` or `critical` vulnerabilities.
-
-GitHub private vulnerability reporting is also currently disabled. Enable it when possible, then update `SECURITY.md` to point reporters directly to the private reporting flow instead of asking them to establish a private channel first.
-
-CodeQL is already configured in source control for Python and JavaScript/TypeScript. Dependabot version updates are also configured; production Docker runtime **major** jumps remain deliberate compatibility work rather than automatic version-update PRs.
+- [x] Dependency graph is enabled. The previously failing Dependency Review run was rerun after the repository setting changed and completed successfully.
+- [x] Pull-request Dependency Review is present and fails on newly introduced high-severity dependency risk according to the source-controlled workflow policy.
+- [x] CodeQL is configured for Python and JavaScript/TypeScript.
+- [x] Dependabot version updates are configured; production Docker runtime **major** jumps remain deliberate compatibility work rather than automatic version-update PRs.
+- [ ] GitHub private vulnerability reporting is currently disabled. Enable it when possible, then update `SECURITY.md` to point reporters directly to the private reporting flow instead of asking them to establish a private channel first.
 
 ## Discussions
 
@@ -45,4 +46,4 @@ Enable GitHub Discussions when there is enough external traffic to justify a low
 
 ## Release gate
 
-Do not weaken the real-provider release gate merely because repository-level settings are incomplete. `v0.2.0` remains blocked until the required real-provider smoke test passes with a real credential.
+Do not weaken the real-provider release gate merely because repository-level settings are incomplete. `v0.2.0` remains blocked until the required real-inference smoke test completes successfully. The fallback local Ollama path is valid only when the workflow installs a real runtime, loads a real model, and completes the application-level connection/chat/restart loop; mocks or a successful model download alone do not satisfy the gate.

--- a/packages/providers/src/personal_ai_os_providers/__init__.py
+++ b/packages/providers/src/personal_ai_os_providers/__init__.py
@@ -10,11 +10,13 @@ from .base import (
     ProviderTool,
     ProviderToolCall,
 )
+from .ollama import OllamaAdapter
 from .openai import OpenAIAdapter
 from .registry import ProviderRegistry
 
 __all__ = [
     "AnthropicAdapter",
+    "OllamaAdapter",
     "OpenAIAdapter",
     "ProviderAdapter",
     "ProviderCancelled",

--- a/packages/providers/src/personal_ai_os_providers/ollama.py
+++ b/packages/providers/src/personal_ai_os_providers/ollama.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from typing import Any
+
 import httpx
 
 from .base import ProviderNotConfigured, validate_model
@@ -24,9 +27,11 @@ class OllamaAdapter(OpenAIAdapter):
         retry_base_seconds: float = 0.25,
         *,
         endpoint: str = DEFAULT_OLLAMA_ENDPOINT,
+        max_output_tokens: int | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._enabled = enabled
+        self._max_output_tokens = max_output_tokens
         super().__init__(
             "ollama",
             models,
@@ -43,6 +48,20 @@ class OllamaAdapter(OpenAIAdapter):
 
     def _headers(self) -> dict[str, str]:
         return {"Content-Type": "application/json"}
+
+    def _bounded_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._max_output_tokens is None:
+            return payload
+        bounded = dict(payload)
+        bounded.setdefault("max_tokens", self._max_output_tokens)
+        return bounded
+
+    async def _post_json(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await super()._post_json(self._bounded_payload(payload))
+
+    async def _stream_payload(self, payload: dict[str, Any]) -> AsyncIterator[str]:
+        async for chunk in super()._stream_payload(self._bounded_payload(payload)):
+            yield chunk
 
     def _validate(self, model: str) -> None:
         if not self._enabled:

--- a/packages/providers/src/personal_ai_os_providers/ollama.py
+++ b/packages/providers/src/personal_ai_os_providers/ollama.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import httpx
+
+from .base import ProviderNotConfigured, validate_model
+from .openai import OpenAIAdapter
+
+
+DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434/v1/chat/completions"
+
+
+class OllamaAdapter(OpenAIAdapter):
+    """Local Ollama inference through its OpenAI-compatible chat-completions API."""
+
+    id = "ollama"
+    provider_name = "Ollama"
+
+    def __init__(
+        self,
+        enabled: bool,
+        models: tuple[str, ...],
+        timeout_seconds: float = 90,
+        max_retries: int = 2,
+        retry_base_seconds: float = 0.25,
+        *,
+        endpoint: str = DEFAULT_OLLAMA_ENDPOINT,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._enabled = enabled
+        super().__init__(
+            "ollama",
+            models,
+            timeout_seconds,
+            max_retries,
+            retry_base_seconds,
+            endpoint=endpoint,
+            transport=transport,
+        )
+
+    @property
+    def configured(self) -> bool:
+        return self._enabled
+
+    def _headers(self) -> dict[str, str]:
+        return {"Content-Type": "application/json"}
+
+    def _validate(self, model: str) -> None:
+        if not self._enabled:
+            raise ProviderNotConfigured("Ollama is not enabled on the server")
+        validate_model(model, self.models)

--- a/packages/providers/src/personal_ai_os_providers/openai.py
+++ b/packages/providers/src/personal_ai_os_providers/openai.py
@@ -24,6 +24,7 @@ from .base import (
 
 class OpenAIAdapter:
     id = "openai"
+    provider_name = "OpenAI"
 
     def __init__(
         self,
@@ -85,19 +86,21 @@ class OpenAIAdapter:
         item = await self._post_json(payload)
         try:
             call = item["choices"][0]["message"]["tool_calls"][0]
-            arguments = json.loads(call["function"]["arguments"])
+            raw_arguments = call["function"]["arguments"]
+            arguments = json.loads(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
             if not isinstance(arguments, dict):
                 raise TypeError
             if str(call["function"]["name"]) != safe_tool_name:
                 raise TypeError
             return ProviderToolCall(
-                id=str(call.get("id") or "openai-tool-call"),
+                id=str(call.get("id") or f"{self.id}-tool-call"),
                 name=tool.name,
                 arguments=arguments,
             )
         except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
             raise ProviderError(
-                "OpenAI returned an invalid tool call", code="invalid_tool_call"
+                f"{self.provider_name} returned an invalid tool call",
+                code="invalid_tool_call",
             ) from exc
 
     async def _post_json(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -110,7 +113,7 @@ class OpenAIAdapter:
                         self._endpoint, headers=self._headers(), json=payload
                     )
                 if response.is_error:
-                    raise error_for_status("OpenAI", response.status_code)
+                    raise error_for_status(self.provider_name, response.status_code)
                 item = response.json()
                 if not isinstance(item, dict):
                     raise ValueError
@@ -121,12 +124,16 @@ class OpenAIAdapter:
             except httpx.TimeoutException as exc:
                 if attempt >= self._max_retries:
                     raise ProviderTimeout(
-                        "OpenAI request timed out", code="timeout", retryable=True
+                        f"{self.provider_name} request timed out",
+                        code="timeout",
+                        retryable=True,
                     ) from exc
             except (httpx.HTTPError, ValueError) as exc:
                 if attempt >= self._max_retries:
                     raise ProviderError(
-                        "OpenAI request failed", code="network_error", retryable=True
+                        f"{self.provider_name} request failed",
+                        code="network_error",
+                        retryable=True,
                     ) from exc
             await retry_pause(attempt, self._retry_base_seconds)
         raise AssertionError("retry loop exhausted")
@@ -166,6 +173,7 @@ class OpenAIAdapter:
                 {
                     "role": "tool",
                     "tool_call_id": call.id,
+                    "tool_name": safe_name,
                     "content": json.dumps(result, ensure_ascii=False),
                 },
             ]
@@ -186,7 +194,7 @@ class OpenAIAdapter:
                         "POST", self._endpoint, headers=self._headers(), json=payload
                     ) as response:
                         if response.is_error:
-                            raise error_for_status("OpenAI", response.status_code)
+                            raise error_for_status(self.provider_name, response.status_code)
                         async for line in response.aiter_lines():
                             if not line.startswith("data: "):
                                 continue
@@ -201,7 +209,7 @@ class OpenAIAdapter:
                                 yield str(delta)
                 if not completed:
                     raise ProviderStreamInterrupted(
-                        "OpenAI stream ended before completion",
+                        f"{self.provider_name} stream ended before completion",
                         code="stream_interrupted",
                         retryable=not emitted,
                     )
@@ -214,12 +222,14 @@ class OpenAIAdapter:
             except httpx.TimeoutException as exc:
                 if emitted or attempt >= self._max_retries:
                     raise ProviderTimeout(
-                        "OpenAI stream timed out", code="timeout", retryable=not emitted
+                        f"{self.provider_name} stream timed out",
+                        code="timeout",
+                        retryable=not emitted,
                     ) from exc
             except (httpx.HTTPError, json.JSONDecodeError) as exc:
                 if emitted or attempt >= self._max_retries:
                     raise ProviderStreamInterrupted(
-                        "OpenAI stream was interrupted",
+                        f"{self.provider_name} stream was interrupted",
                         code="stream_interrupted",
                         retryable=not emitted,
                     ) from exc
@@ -227,5 +237,7 @@ class OpenAIAdapter:
 
     def _validate(self, model: str) -> None:
         if not self._api_key:
-            raise ProviderNotConfigured("OpenAI is not configured on the server")
+            raise ProviderNotConfigured(
+                f"{self.provider_name} is not configured on the server"
+            )
         validate_model(model, self.models)

--- a/packages/providers/src/personal_ai_os_providers/openai.py
+++ b/packages/providers/src/personal_ai_os_providers/openai.py
@@ -173,7 +173,6 @@ class OpenAIAdapter:
                 {
                     "role": "tool",
                     "tool_call_id": call.id,
-                    "tool_name": safe_name,
                     "content": json.dumps(result, ensure_ascii=False),
                 },
             ]

--- a/scripts/release-provider-smoke.py
+++ b/scripts/release-provider-smoke.py
@@ -15,11 +15,14 @@ import httpx
 
 
 ROOT = Path(__file__).resolve().parents[1]
-KEY_ENV = {
+PROVIDER_SECRET_ENV: dict[str, str | None] = {
     "openai": "PERSONAL_AI_OS_OPENAI_API_KEY",
     "anthropic": "PERSONAL_AI_OS_ANTHROPIC_API_KEY",
+    "ollama": None,
 }
-ALL_SECRET_ENV = tuple(KEY_ENV.values()) + ("PERSONAL_AI_OS_REALTIME_API_KEY",)
+ALL_SECRET_ENV = tuple(
+    name for name in PROVIDER_SECRET_ENV.values() if name is not None
+) + ("PERSONAL_AI_OS_REALTIME_API_KEY",)
 
 
 class SmokeFailure(RuntimeError):
@@ -40,18 +43,25 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
-def _environment(data_dir: Path, *, provider: str, include_credential: bool) -> dict[str, str]:
+def _environment(data_dir: Path, *, provider: str, enable_provider: bool) -> dict[str, str]:
     env = os.environ.copy()
-    credential = env.get(KEY_ENV[provider], "")
+    credential_env = PROVIDER_SECRET_ENV[provider]
+    credential = env.get(credential_env, "") if credential_env else ""
     for name in ALL_SECRET_ENV:
         env.pop(name, None)
     env["PERSONAL_AI_OS_DATA_DIR"] = str(data_dir)
     env["PERSONAL_AI_OS_REQUIRE_AUTH"] = "false"
+    env["PERSONAL_AI_OS_OLLAMA_ENABLED"] = "false"
     env["PYTHONUNBUFFERED"] = "1"
-    if include_credential:
-        if not credential:
-            _fail(f"Missing required server-side credential environment variable: {KEY_ENV[provider]}")
-        env[KEY_ENV[provider]] = credential
+    if enable_provider:
+        if provider == "ollama":
+            env["PERSONAL_AI_OS_OLLAMA_ENABLED"] = "true"
+        else:
+            if not credential_env or not credential:
+                _fail(
+                    f"Missing required server-side credential environment variable: {credential_env}"
+                )
+            env[credential_env] = credential
     return env
 
 
@@ -126,7 +136,13 @@ def _provider(client: httpx.Client, provider_id: str) -> dict[str, Any]:
     _fail(f"Provider is not registered: {provider_id}")
 
 
-def _chat(client: httpx.Client, provider: str, model: str, content: str, conversation_id: str | None = None) -> str:
+def _chat(
+    client: httpx.Client,
+    provider: str,
+    model: str,
+    content: str,
+    conversation_id: str | None = None,
+) -> str:
     payload: dict[str, Any] = {
         "provider": provider,
         "model": model,
@@ -153,8 +169,14 @@ def _chat(client: httpx.Client, provider: str, model: str, content: str, convers
         _fail("Chat stream emitted no execution events")
     errors = [item for item in events if item.get("type") == "error"]
     if errors:
-        code = ((errors[-1].get("payload") or {}).get("code") if isinstance(errors[-1].get("payload"), dict) else None)
-        _fail(f"Chat stream reported a provider/application error{f' ({code})' if code else ''}")
+        code = (
+            (errors[-1].get("payload") or {}).get("code")
+            if isinstance(errors[-1].get("payload"), dict)
+            else None
+        )
+        _fail(
+            f"Chat stream reported a provider/application error{f' ({code})' if code else ''}"
+        )
     done = next((item for item in reversed(events) if item.get("type") == "done"), None)
     if not done or done.get("status") != "succeeded":
         _fail("Chat stream did not finish successfully")
@@ -177,16 +199,20 @@ def _assert_conversation(client: httpx.Client, conversation_id: str, minimum_mes
 
 
 def run(provider: str, requested_model: str | None, *, no_key_only: bool = False) -> None:
-    if provider not in KEY_ENV:
+    if provider not in PROVIDER_SECRET_ENV:
         _fail(f"Unsupported provider: {provider}")
-    if not no_key_only and not os.getenv(KEY_ENV[provider]):
-        _fail(f"Set {KEY_ENV[provider]} in the current shell; the script never prints or writes its value")
+    credential_env = PROVIDER_SECRET_ENV[provider]
+    if not no_key_only and credential_env and not os.getenv(credential_env):
+        _fail(
+            f"Set {credential_env} in the current shell; the script never prints or writes its value"
+        )
 
     with tempfile.TemporaryDirectory(prefix="personal-ai-os-release-smoke-") as temp_dir:
         data_dir = Path(temp_dir)
 
-        # Phase 1: fresh install with no provider credential.
-        process, base_url = _start_api(_environment(data_dir, provider=provider, include_credential=False))
+        process, base_url = _start_api(
+            _environment(data_dir, provider=provider, enable_provider=False)
+        )
         try:
             with httpx.Client(base_url=base_url, timeout=20) as client:
                 health = _json(client, "GET", "/health")
@@ -194,12 +220,12 @@ def run(provider: str, requested_model: str | None, *, no_key_only: bool = False
                     _fail("Runtime health version is not aligned to v0.2.0")
                 item = _provider(client, provider)
                 if item.get("configured") is not False:
-                    _fail("Fresh no-key startup unexpectedly reports the provider as configured")
+                    _fail("Fresh no-provider startup unexpectedly reports the provider as configured")
                 settings = _json(client, "GET", "/api/settings")
                 secrets = settings.get("secrets")
                 if secrets != {"storage": "environment", "values_exposed": False}:
                     _fail("Settings secret boundary is not fail-closed")
-            _pass("fresh install starts safely with provider unconfigured and secrets hidden")
+            _pass("fresh install starts safely with provider disabled/unconfigured and secrets hidden")
         finally:
             _stop_api(process)
 
@@ -207,8 +233,9 @@ def run(provider: str, requested_model: str | None, *, no_key_only: bool = False
             _pass("no-key readiness gate completed without provider credentials or billable model calls")
             return
 
-        # Phase 2: restart with the real credential and exercise a complete chat turn.
-        process, base_url = _start_api(_environment(data_dir, provider=provider, include_credential=True))
+        process, base_url = _start_api(
+            _environment(data_dir, provider=provider, enable_provider=True)
+        )
         try:
             with httpx.Client(base_url=base_url, timeout=30) as client:
                 item = _provider(client, provider)
@@ -220,7 +247,9 @@ def run(provider: str, requested_model: str | None, *, no_key_only: bool = False
                     _fail(f"Requested model is not allowlisted for {provider}: {model}")
                 checked = _json(client, "POST", f"/api/providers/{provider}/check")
                 if checked.get("status") != "connected":
-                    _fail(f"Live provider connection check did not connect (status={checked.get('status')})")
+                    _fail(
+                        f"Live provider connection check did not connect (status={checked.get('status')})"
+                    )
                 saved = _json(
                     client,
                     "PATCH",
@@ -235,8 +264,9 @@ def run(provider: str, requested_model: str | None, *, no_key_only: bool = False
         finally:
             _stop_api(process)
 
-        # Phase 3: restart again against the same isolated data directory and verify persistence.
-        process, base_url = _start_api(_environment(data_dir, provider=provider, include_credential=True))
+        process, base_url = _start_api(
+            _environment(data_dir, provider=provider, enable_provider=True)
+        )
         try:
             with httpx.Client(base_url=base_url, timeout=30) as client:
                 settings = _json(client, "GET", "/api/settings")
@@ -264,12 +294,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Fail-closed v0.2.0 readiness smoke test. Never prints provider credentials or response text."
     )
-    parser.add_argument("--provider", choices=sorted(KEY_ENV), default="openai")
+    parser.add_argument("--provider", choices=sorted(PROVIDER_SECRET_ENV), default="openai")
     parser.add_argument("--model", default=None, help="Optional allowlisted model override")
     parser.add_argument(
         "--no-key-only",
         action="store_true",
-        help="Verify fresh no-key startup and secret boundaries without requiring a provider credential or making billable model calls.",
+        help="Verify fresh no-provider startup and secret boundaries without requiring a credential or making billable model calls.",
     )
     args = parser.parse_args()
     try:


### PR DESCRIPTION
## Summary

Prepare the first stable `v0.2.0` release without weakening the fail-closed release contract.

- position Personal AI OS explicitly as a local-first, provider-neutral persistent workspace rather than an account switcher or thin chat client;
- add an optional local Ollama adapter beside OpenAI and Anthropic using Ollama's OpenAI-compatible chat-completions boundary;
- keep Ollama disabled by default so fresh installs remain fail-closed and do not falsely report a local provider as configured;
- make release-branch CI perform a real application-level inference loop with a pinned local Ollama runtime and a small allowlisted model when no maintainer-owned OpenAI/Anthropic release secret is configured;
- verify fresh no-provider startup, secret redaction, live provider connection, default provider/model persistence, a real text-chat turn, API restart, and continued persisted conversation state;
- include Windows no-key readiness plus production Docker health and PWA/mobile readiness in the platform gate;
- restore Dependency Review as a source-controlled high-severity dependency gate;
- update README, changelog, roadmap, release notes, release checklist, UI provider naming, and repository-admin evidence to the same v0.2 product contract.

## Why local Ollama for the release gate

The prior experimental PR #34 correctly failed closed when its proposed GitHub Models fallback returned HTTP 410; that provider service had been retired and #34 was closed without merge. This RC is rebuilt from clean `main` and does not depend on GitHub Models.

The Ollama fallback is not a mock or fixture. The workflow installs a pinned runtime on the isolated runner, pulls a real small model, and exercises the same FastAPI/provider/chat/persistence path used by the application. OpenAI/Anthropic repository secrets still take precedence when explicitly configured.

## Safety / scope

- no API key or private runtime data is added to the repository;
- Ollama is explicit opt-in for normal application use;
- model response text is not printed by the release smoke runner;
- the `v0.2.0` changelog is dated 2026-08-15, but no tag or GitHub Release is created by this PR;
- publication still requires every final release checklist gate to pass on the verified release candidate;
- cloud identity/billing remains fail-closed and out of scope.

## Required evidence before merge

- backend tests, package-version consistency, Python compilation, and no-key startup green;
- frontend type checks/build green;
- CodeQL, Dependency Review, Windows/container/mobile Platform Readiness green;
- Release provider smoke green with real inference and restart continuity;
- final diff contains no secret/private-runtime artifact.
