### PR TITLE
ci: make GitHub Release publication auditable

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,70 @@
+name: Publish GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish (for example v0.2.0)
+        required: true
+        default: v0.2.0
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository history and tags
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Validate release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid release tag::Expected a version tag such as v0.2.0."
+            exit 1
+          fi
+
+          git fetch origin main --tags --force --quiet
+          git rev-parse "refs/tags/$TAG^{commit}" >/dev/null
+
+          TAG_COMMIT="$(git rev-parse "refs/tags/$TAG^{commit}")"
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error title=Untrusted release tag::The tag commit is not reachable from origin/main."
+            exit 1
+          fi
+
+          echo "Validated $TAG at $TAG_COMMIT"
+
+      - name: Refuse duplicate publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error title=Release already exists::A GitHub Release already exists for $TAG."
+            exit 1
+          fi
+
+      - name: Publish verified tag as GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --verify-tag \
+            --generate-notes \
+            --title "Personal AI OS $TAG"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ under the user's control.
 
 ## Early testers wanted
 
-Personal AI OS is preparing its first stable `v0.2.0` release. **You do not need a paid API key to help test it.**
+Personal AI OS `v0.2.0` is now the first stable tagged release. **You do not need a paid API key to help test it.**
 
 - **No API key:** follow [Try without an API key](docs/try-without-api.md) or run `python scripts/release-provider-smoke.py --provider openai --no-key-only` after installing the Python dependencies. This makes no billable model call.
 - **Have your own provider credential:** use [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7) for the full provider → first chat → restart-persistence path. OpenAI and Anthropic are supported remote adapters; Ollama is supported as an explicitly enabled local adapter.
@@ -28,7 +28,7 @@ Personal AI OS is preparing its first stable `v0.2.0` release. **You do not need
 - Never post API keys, `.env` files, authorization headers, cookies, private conversations,
   runtime databases, logs containing secrets, uploads/backups, or private project data.
 
-The zero-cost path verifies safe startup, runtime version, unconfigured-provider behavior, and secret redaction. It does **not** substitute for the real-provider release gate. Release-branch CI can execute that gate with a pinned local Ollama runtime and a small real model when no maintainer-owned OpenAI or Anthropic secret is configured; model response text is not printed by the smoke runner.
+The zero-cost path verifies safe startup, runtime version, unconfigured-provider behavior, and secret redaction. For future `release/*` candidates, CI can execute the real-inference gate with a pinned local Ollama runtime and a small real model when no maintainer-owned OpenAI or Anthropic secret is configured; model response text is not printed by the smoke runner.
 
 ## Maintenance and security
 
@@ -39,7 +39,7 @@ Repository maintenance is executable rather than release-note-only:
 - CodeQL analyzes Python and JavaScript/TypeScript on pull requests, `main`, and a weekly schedule;
 - Dependency Review fails closed on newly introduced high-severity dependency risk;
 - Dependabot checks JavaScript, Python, GitHub Actions, and Docker dependencies weekly; production Docker runtime major jumps remain deliberate compatibility work rather than automatic version updates;
-- `release/*` pull requests run an isolated real-provider smoke before `v0.2.0` can be published.
+- `release/*` pull requests run an isolated real-provider smoke before a future stable release is published.
 
 Repository-admin settings that source-controlled CI cannot replace are tracked honestly in [`docs/repository-admin-checklist.md`](docs/repository-admin-checklist.md).
 
@@ -177,7 +177,7 @@ registry; this does not restrict use of the source code under Apache-2.0. See
 security issue. The initial problem statement and honest first-party usage case are
 documented in `docs/dogfooding.md`.
 
-The focused path from the current release candidate to a usable public product is in
+The focused path from the current stable release to a usable public product is in
 `ROADMAP.md`.
 The positioning, delivery-mode, terminology, capability, and tenant contracts are in
 `docs/product-contract.md`.


### PR DESCRIPTION
## Why

`v0.2.0` already exists as a verified tag on the stable release commit, but the repository does not yet have a GitHub Release object. Release management is an important public maintenance signal, and publication should remain evidence-based rather than becoming a manual unverified click path.

## What this adds

- a manual `Publish GitHub Release` workflow;
- accepts an explicit version tag such as `v0.2.0`;
- rejects malformed tags;
- requires the tag to already exist;
- requires the tagged commit to be reachable from `origin/main`;
- refuses to overwrite or duplicate an existing GitHub Release;
- uses GitHub's own token only for `gh release create`;
- publishes generated release notes from the verified tag.

## Safety

- no provider credentials or application secrets are read;
- no model/API call is made;
- release publication remains an explicit maintainer action;
- the workflow cannot invent a release tag or publish an unrelated commit.

## Follow-up after merge

Dispatch the workflow once with `v0.2.0` to create the missing public GitHub Release page for the already-tagged stable release.