### PR TITLE
docs: formalize maintainer and stable security policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Maintainers
+
+Personal AI OS is currently maintained by a small maintainer group.
+
+## Primary maintainer
+
+- **@sui-ni2** — primary maintainer and repository administrator.
+
+The primary maintainer is responsible for roadmap decisions, issue triage, pull-request review and merge decisions, release management, dependency/security maintenance, and keeping public project claims aligned with verifiable repository evidence.
+
+## Maintenance policy
+
+- Non-trivial product and infrastructure changes should go through pull requests and the repository CI/security gates.
+- Reproducible bugs, release blockers, and external tester feedback belong in Issues so they remain actionable and auditable.
+- Security-sensitive changes receive explicit review of credential, authentication, MCP/tool, persistence, and deployment boundaries.
+- Stable releases are cut only from commits reachable from `main` after the documented release gates pass.
+- Adoption signals must be genuine. Maintainers do not create synthetic user feedback, stars, forks, testimonials, or usage claims.
+
+## Adding maintainers
+
+Maintainer access is not granted solely for a single contribution. Candidates should demonstrate sustained, useful contributions; sound review judgment; respect for privacy/security boundaries; and willingness to help triage issues and maintain releases. Repository permissions are expanded deliberately as the contributor base grows.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,10 @@
 
 ## Supported versions
 
-Security fixes currently target the latest code on the default branch. A formal
-multi-version support policy will be published with the first stable release.
+Security fixes target the latest stable `v0.2.x` release line and the current `main` branch.
+Versions older than `v0.2.0` are pre-stable historical builds and are not supported.
+When a fix affects the current stable release, maintainers will decide whether a focused
+backport is safer than requiring users to move to the next stable release.
 
 ## Reporting a vulnerability
 

--- a/docs/repository-admin-checklist.md
+++ b/docs/repository-admin-checklist.md
@@ -4,7 +4,9 @@ These settings live in GitHub repository administration rather than the source t
 
 ## Discoverability
 
-Add focused repository topics after confirming they accurately describe the project. Recommended starting set:
+- [ ] Add focused repository topics. The repository API currently reports no topics.
+
+Recommended starting set:
 
 - `personal-ai`
 - `ai-workbench`
@@ -20,17 +22,17 @@ Avoid broad or misleading tags that imply integrations or production capabilitie
 
 ## Main branch protection
 
-Protect `main` (or use a repository ruleset) so that normal changes go through pull requests and required CI.
+- [ ] Protect `main` (or use a repository ruleset) so that normal changes go through pull requests and required CI. The repository API currently reports `main` as unprotected.
 
 Target policy:
 
 - require a pull request before merge;
-- require the existing backend and frontend CI checks to pass;
+- require the existing backend/frontend CI and security checks to pass;
 - block force pushes and branch deletion;
 - keep maintainer bypass exceptional rather than routine;
 - do not require an external approval while the project has only one maintainer, unless a second trusted maintainer is added.
 
-The connected GitHub integration cannot read the branch-protection endpoint for this repository, so this setting remains an explicit repository-admin verification item rather than source-controlled evidence.
+The connected GitHub integration does not expose a branch-protection write action, so this remains a repository-admin task rather than source-controlled evidence.
 
 ## Security analysis settings
 
@@ -44,6 +46,11 @@ The connected GitHub integration cannot read the branch-protection endpoint for 
 
 Enable GitHub Discussions when there is enough external traffic to justify a lower-friction Q&A/ideas channel. Keep reproducible bugs and release blockers in Issues so they remain actionable.
 
-## Release gate
+## Release evidence
 
-Do not weaken the real-provider release gate merely because repository-level settings are incomplete. `v0.2.0` remains blocked until the required real-inference smoke test completes successfully. The fallback local Ollama path is valid only when the workflow installs a real runtime, loads a real model, and completes the application-level connection/chat/restart loop; mocks or a successful model download alone do not satisfy the gate.
+- [x] `v0.2.0` is a stable tag on the verified release commit.
+- [x] The release candidate passed CI, CodeQL, Dependency Review, Platform Readiness, and the application-level real-inference release smoke before tagging.
+- [x] `.github/workflows/publish-release.yml` provides a fail-closed publication path that only accepts an existing version tag reachable from `main` and refuses duplicate publication.
+- [ ] Publish the GitHub Release object for `v0.2.0`. The connected GitHub integration can merge the workflow but does not expose `workflow_dispatch`, so this final repository-admin action cannot be triggered from the integration.
+
+Future stable releases must keep the same evidence standard: real application-level inference, restart/persistence verification, normal CI/security/platform checks, and an auditable release publication path. A successful model download or mock alone does not satisfy the release gate.


### PR DESCRIPTION
## Why

The repository now has a stable `v0.2.0` tag, but two public maintenance documents still reflected the pre-release state and maintainer responsibilities were implicit rather than documented.

## What changed

- add `MAINTAINERS.md` naming the current primary maintainer and the concrete responsibilities for roadmap, triage, review, releases, and security;
- explicitly prohibit synthetic adoption signals in the maintainer policy;
- update `SECURITY.md` so the supported-version policy reflects the stable `v0.2.x` line instead of promising a policy only after the first stable release;
- update the repository-admin checklist with the currently observable blockers: no repository topics, unprotected `main`, private vulnerability reporting disabled, and the missing GitHub Release object for the already-verified `v0.2.0` tag;
- record that the connected integration cannot mutate branch protection or dispatch the release workflow, rather than pretending those settings are complete.

## Scope

Documentation/governance only. No runtime behavior, credentials, CI gates, or release tag changes.