### PR TITLE
docs: correct v0.2.0 release evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Product roadmap
 
-Personal AI OS is currently a `v0.2.0` release candidate. The core first-use loop now exists: the community edition can start safely without credentials, connect a supported AI service, persist a default provider/model, complete text conversations, retain project/conversation state across restart, and expose tools and reviewed memory without binding that state to one model provider.
+Personal AI OS has published its first stable community/self-hosted release, `v0.2.0`. The core first-use loop is verified: the community edition can start safely without credentials, connect a supported AI service, persist a default provider/model, complete text conversations, retain project/conversation state across restart, and expose tools and reviewed memory without binding that state to one model provider.
 
-The release remains fail-closed until the final real-inference and privacy/artifact gates pass. A release candidate is not treated as a stable release merely because the feature set exists.
+The stable release was published only after the documented real-inference, restart/persistence, CI, security, Windows/container/mobile, and privacy/artifact gates passed. Future releases remain fail-closed against the same evidence standard.
 
 ## Current product contract
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -66,7 +66,7 @@ Ollama is disabled during the fresh no-provider phase and enabled only for the r
 
 ### Verified evidence
 
-PR #35 release head `a2e09202448e543eb99c20a7085e2e3b9408a4ef` passed all five release lines before this checklist-only evidence update:
+PR #35 release head `a2e09202448e543eb99c20a7085e2e3b9408a4ef` passed all five release lines before the checklist-only evidence update:
 
 - CI — success
 - CodeQL — success
@@ -74,19 +74,17 @@ PR #35 release head `a2e09202448e543eb99c20a7085e2e3b9408a4ef` passed all five r
 - Platform Readiness — success, including Windows no-key and production Docker/PWA checks
 - Release provider smoke — success with real local Ollama inference, persisted provider/model selection, API restart, and continued conversation state
 
-This checklist update changes documentation only. The resulting final PR head must still remain green before merge.
+The checklist-only update also remained green before merge.
 
-### Publication
+### Publication — completed
 
-Only after the final checklist head remains green:
-
-1. Merge PR #35 to `main`.
-2. Verify post-merge `main` CI/security/platform checks.
-3. Close Issue #1 with sanitized evidence because its fresh-install/provider acceptance criteria are satisfied.
-4. Create tag `v0.2.0` from the verified `main` commit.
-5. Publish GitHub Release `v0.2.0` with concise release notes and known limitations.
-6. Verify the release tag points to the intended commit and no secret/private artifact is attached.
+- [x] PR #35 merged to `main`.
+- [x] Post-merge release evidence remained consistent with the verified release candidate.
+- [x] Issue #1 was closed as completed with sanitized acceptance evidence.
+- [x] Stable tag `v0.2.0` points to the intended verified `main` commit.
+- [x] Public GitHub Release `Personal AI OS v0.2.0` was published on 2026-08-15; it is neither a draft nor a prerelease.
+- [x] The public release has no attached private/generated artifacts; GitHub provides the normal source tarball/zipball for the tag.
 
 ## Fail-closed rule
 
-If the real-provider smoke test cannot execute or does not complete successfully, keep Issue #1 open and do not publish `v0.2.0`. The existence of a workflow, a successful model download, or green unit tests is not release evidence by itself; the complete application-level real-inference loop must pass.
+If a future release's real-provider smoke test cannot execute or does not complete successfully, do not create its stable release tag or publish its GitHub Release. The existence of a workflow, a successful model download, or green unit tests is not release evidence by itself; the complete application-level real-inference loop must pass.

--- a/docs/repository-admin-checklist.md
+++ b/docs/repository-admin-checklist.md
@@ -50,7 +50,7 @@ Enable GitHub Discussions when there is enough external traffic to justify a low
 
 - [x] `v0.2.0` is a stable tag on the verified release commit.
 - [x] The release candidate passed CI, CodeQL, Dependency Review, Platform Readiness, and the application-level real-inference release smoke before tagging.
-- [x] `.github/workflows/publish-release.yml` provides a fail-closed publication path that only accepts an existing version tag reachable from `main` and refuses duplicate publication.
-- [ ] Publish the GitHub Release object for `v0.2.0`. The connected GitHub integration can merge the workflow but does not expose `workflow_dispatch`, so this final repository-admin action cannot be triggered from the integration.
+- [x] `Personal AI OS v0.2.0` is published as a public GitHub Release; it is neither a draft nor a prerelease.
+- [x] `.github/workflows/publish-release.yml` provides a fail-closed publication path. Manual runs require an existing valid tag reachable from `main`; automatic runs only consider an existing strict stable `vN.N.N` tag and no-op if the GitHub Release already exists.
 
-Future stable releases must keep the same evidence standard: real application-level inference, restart/persistence verification, normal CI/security/platform checks, and an auditable release publication path. A successful model download or mock alone does not satisfy the release gate.
+Future stable releases must keep the same evidence standard: real application-level inference, restart/persistence verification, normal CI/security/platform checks, an explicit stable tag, and an auditable release publication path. A successful model download or mock alone does not satisfy the release gate.


### PR DESCRIPTION
## Why

A broad releases-list lookup returned an empty result, but the exact tag endpoint and `gh release view v0.2.0` both confirm that `Personal AI OS v0.2.0` is already publicly published and is neither a draft nor a prerelease. Several public documents still contained pre-release state and should reflect the stronger exact evidence.

## Changes

- mark the public `v0.2.0` GitHub Release as verified in the repository-admin checklist;
- describe the current self-healing publication workflow accurately;
- remove the false remaining release blocker;
- update `ROADMAP.md` from “current release candidate / final gates pending” to the verified stable-release state;
- convert the v0.2.0 publication section of the release checklist into completed, auditable evidence and retain fail-closed requirements for future releases.

Documentation only.