### PR TITLE
docs: record completed repository hardening

### DIFF
--- a/docs/repository-admin-checklist.md
+++ b/docs/repository-admin-checklist.md
@@ -4,9 +4,9 @@ These settings live in GitHub repository administration rather than the source t
 
 ## Discoverability
 
-- [ ] Add focused repository topics. The repository API currently reports no topics.
+- [x] Focused repository topics are configured and verified.
 
-Recommended starting set:
+Current set:
 
 - `personal-ai`
 - `ai-workbench`
@@ -22,17 +22,19 @@ Avoid broad or misleading tags that imply integrations or production capabilitie
 
 ## Main branch protection
 
-- [ ] Protect `main` (or use a repository ruleset) so that normal changes go through pull requests and required CI. The repository API currently reports `main` as unprotected.
+- [x] The default branch is protected by the active repository ruleset `Protect main`.
 
-Target policy:
+Verified policy:
 
-- require a pull request before merge;
-- require the existing backend/frontend CI and security checks to pass;
-- block force pushes and branch deletion;
-- keep maintainer bypass exceptional rather than routine;
-- do not require an external approval while the project has only one maintainer, unless a second trusted maintainer is added.
+- pull requests are required before merge;
+- required GitHub Actions checks are `backend`, `frontend`, `Analyze (javascript-typescript)`, `Analyze (python)`, and `dependency-review`;
+- review conversations must be resolved before merge;
+- force pushes are blocked;
+- branch deletion is blocked;
+- there is no routine bypass actor;
+- external approval is not required while the project has only one trusted maintainer.
 
-The connected GitHub integration does not expose a branch-protection write action, so this remains a repository-admin task rather than source-controlled evidence.
+If a second trusted maintainer is added, reassess whether an approval requirement improves review quality without making maintenance brittle.
 
 ## Security analysis settings
 
@@ -40,7 +42,8 @@ The connected GitHub integration does not expose a branch-protection write actio
 - [x] Pull-request Dependency Review is present and fails on newly introduced high-severity dependency risk according to the source-controlled workflow policy.
 - [x] CodeQL is configured for Python and JavaScript/TypeScript.
 - [x] Dependabot version updates are configured; production Docker runtime **major** jumps remain deliberate compatibility work rather than automatic version-update PRs.
-- [ ] GitHub private vulnerability reporting is currently disabled. Enable it when possible, then update `SECURITY.md` to point reporters directly to the private reporting flow instead of asking them to establish a private channel first.
+- [x] GitHub private vulnerability reporting is enabled.
+- [x] `SECURITY.md` directs vulnerability reports to GitHub's private reporting flow and keeps sensitive exploit details, credentials, private conversations, logs, and deployment data out of public issues.
 
 ## Discussions
 
@@ -54,3 +57,7 @@ Enable GitHub Discussions when there is enough external traffic to justify a low
 - [x] `.github/workflows/publish-release.yml` provides a fail-closed publication path. Manual runs require an existing valid tag reachable from `main`; automatic runs only consider an existing strict stable `vN.N.N` tag and no-op if the GitHub Release already exists.
 
 Future stable releases must keep the same evidence standard: real application-level inference, restart/persistence verification, normal CI/security/platform checks, an explicit stable tag, and an auditable release publication path. A successful model download or mock alone does not satisfy the release gate.
+
+## Adoption evidence boundary
+
+Repository hardening, CI, release management, Stars, and Forks are useful maintenance/discoverability signals but are not proof that someone has successfully used the software. Genuine tester comments, reproducible external issues, focused external pull requests, and independently verifiable user stories remain the preferred adoption evidence.


### PR DESCRIPTION
## Why

The repository-admin checklist still described topics, branch protection, and private vulnerability reporting as incomplete even though those settings are now verified in GitHub.

## Changes

- mark the focused repository topics as configured;
- record the active `Protect main` ruleset and its independent required checks;
- record blocked force pushes/deletion and required PR/review-thread resolution;
- mark private vulnerability reporting as enabled and aligned with `SECURITY.md`;
- add an explicit boundary between repository hardening/discoverability signals and genuine external adoption evidence.

Documentation only. No runtime behavior or adoption metrics are changed.