### PR TITLE
docs: route public issues away from security reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ labels:
 body:
   - type: markdown
     attributes:
-      value: Do not include `.env` contents, credentials, conversations, logs, or private project data.
+      value: Security vulnerabilities must be reported privately from the repository Security page. Do not include `.env` contents, credentials, conversations, logs, exploit details, or private project data in a public issue.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sui-ni2/personal-ai-os/security
+    about: Report security vulnerabilities privately through GitHub instead of opening a public issue.


### PR DESCRIPTION
## Why

Private vulnerability reporting is now enabled, but the public issue chooser should make the private security path explicit so reporters do not accidentally disclose exploit details or credentials in a normal issue.

## Changes

- add an Issue chooser contact link to the repository Security page while keeping blank issues available;
- update the Bug report form to explicitly route security vulnerabilities to private reporting;
- reinforce the prohibition on posting credentials, exploit details, private conversations, logs, or private project data publicly.

Issue-routing/documentation only.