### PR TITLE
feat: add one-command Windows first-run bootstrap

### DIFF
--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -56,12 +56,8 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
-      - name: Verify Windows first-run bootstrap prerequisites
-        run: ./scripts/setup-windows.ps1 -CheckOnly
-      - name: Install Python dependencies
-        run: python -m pip install -r requirements-dev.txt
-      - name: Verify fresh no-key readiness on Windows
-        run: python scripts/release-provider-smoke.py --provider openai --no-key-only
+      - name: Verify Windows first-run bootstrap end to end
+        run: ./scripts/setup-windows.ps1
 
   container:
     name: Container build, health, and mobile shell

--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -13,6 +13,7 @@ on:
       - "packages/**"
       - "scripts/release-provider-smoke.py"
       - "scripts/check-mobile-readiness.ps1"
+      - "scripts/setup-windows.ps1"
       - ".github/workflows/platform-readiness.yml"
   push:
     branches: [main]
@@ -26,6 +27,7 @@ on:
       - "packages/**"
       - "scripts/release-provider-smoke.py"
       - "scripts/check-mobile-readiness.ps1"
+      - "scripts/setup-windows.ps1"
       - ".github/workflows/platform-readiness.yml"
   workflow_dispatch:
 
@@ -45,6 +47,17 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-dev.txt
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.16.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+      - name: Verify Windows first-run bootstrap prerequisites
+        run: ./scripts/setup-windows.ps1 -CheckOnly
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt
       - name: Verify fresh no-key readiness on Windows

--- a/docs/try-without-api.md
+++ b/docs/try-without-api.md
@@ -15,9 +15,39 @@ The zero-cost readiness check starts the API against a temporary data directory 
 
 It does **not** certify a real provider connection, model response, or provider-backed conversation. Those remain part of the separate release smoke gate.
 
-## Run the zero-cost check
+## Windows: prepare a fresh checkout in one command
 
-After installing the Python dependencies:
+Prerequisites are Python 3.11+, Node.js 20+, and pnpm 11. The bootstrap does not install system runtimes, does not add a provider credential, and never overwrites an existing `.env` file.
+
+From the repository root, run:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup-windows.ps1
+```
+
+The bootstrap validates the prerequisites, creates `.env` from `.env.example` only when `.env` is missing, creates `.venv` only when needed, installs the repository dependencies, and runs the no-key readiness check. It makes no billable provider model call.
+
+To validate only the prerequisites and repository files without changing the working tree or installing dependencies:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\setup-windows.ps1 -CheckOnly
+```
+
+After setup, start the API and web app in separate terminals:
+
+```powershell
+.\scripts\dev-api.ps1
+```
+
+```powershell
+.\scripts\dev-web.ps1
+```
+
+Then open `http://localhost:3000`.
+
+## Run only the zero-cost check
+
+If the Python dependencies are already installed, run:
 
 ```bash
 python scripts/release-provider-smoke.py --provider openai --no-key-only

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,0 +1,138 @@
+param(
+    [switch]$CheckOnly,
+    [switch]$SkipSmoke
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location -LiteralPath $repoRoot
+
+function Assert-LastExitCode {
+    param([string]$Step)
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    throw "This bootstrap is for Windows. Use the manual setup instructions on other platforms."
+}
+
+$requiredFiles = @(
+    ".env.example",
+    "requirements-dev.txt",
+    "package.json",
+    "pnpm-lock.yaml",
+    "scripts/release-provider-smoke.py"
+)
+foreach ($relativePath in $requiredFiles) {
+    if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath))) {
+        throw "Missing required repository file: $relativePath"
+    }
+}
+
+$pythonCommand = Get-Command py -ErrorAction SilentlyContinue
+$pythonPrefix = @()
+if ($pythonCommand) {
+    $pythonExe = $pythonCommand.Source
+    $pythonPrefix = @("-3")
+} else {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCommand) {
+        throw "Python 3.11+ is required. Install Python, reopen the terminal, and run this script again."
+    }
+    $pythonExe = $pythonCommand.Source
+}
+
+$pythonProbeArgs = @() + $pythonPrefix + @(
+    "-c",
+    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')"
+)
+$pythonVersionText = (& $pythonExe @pythonProbeArgs).Trim()
+Assert-LastExitCode "Python version check"
+try {
+    $pythonVersion = [version]$pythonVersionText
+} catch {
+    throw "Could not parse Python version: $pythonVersionText"
+}
+if ($pythonVersion.Major -ne 3 -or $pythonVersion.Minor -lt 11) {
+    throw "Python 3.11+ is required; found $pythonVersionText."
+}
+
+$nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+if (-not $nodeCommand) {
+    throw "Node.js 20+ is required. Install Node.js, reopen the terminal, and run this script again."
+}
+$nodeVersionText = (& $nodeCommand.Source --version).Trim().TrimStart("v")
+Assert-LastExitCode "Node.js version check"
+try {
+    $nodeVersion = [version]$nodeVersionText
+} catch {
+    throw "Could not parse Node.js version: $nodeVersionText"
+}
+if ($nodeVersion.Major -lt 20) {
+    throw "Node.js 20+ is required; found v$nodeVersionText."
+}
+
+$pnpmCommand = Get-Command pnpm -ErrorAction SilentlyContinue
+if (-not $pnpmCommand) {
+    throw "pnpm 11 is required. Install or activate pnpm, reopen the terminal, and run this script again."
+}
+$pnpmVersionText = (& $pnpmCommand.Source --version).Trim()
+Assert-LastExitCode "pnpm version check"
+try {
+    $pnpmVersion = [version]$pnpmVersionText
+} catch {
+    throw "Could not parse pnpm version: $pnpmVersionText"
+}
+if ($pnpmVersion.Major -ne 11) {
+    throw "pnpm 11 is required to match this repository's package-manager line; found $pnpmVersionText."
+}
+if ($pnpmVersionText -ne "11.16.0") {
+    Write-Warning "Repository packageManager is pinned to pnpm 11.16.0; found $pnpmVersionText. Continuing within pnpm 11."
+}
+
+Write-Host "[PASS] Windows prerequisites: Python $pythonVersionText, Node.js v$nodeVersionText, pnpm $pnpmVersionText"
+
+if ($CheckOnly) {
+    Write-Host "[PASS] Check-only mode completed without changing the working tree or installing dependencies."
+    exit 0
+}
+
+$envPath = Join-Path $repoRoot ".env"
+if (-not (Test-Path -LiteralPath $envPath)) {
+    Copy-Item -LiteralPath (Join-Path $repoRoot ".env.example") -Destination $envPath
+    Write-Host "Created .env from .env.example. No provider credential was added."
+} else {
+    Write-Host "Existing .env preserved; it was not overwritten."
+}
+
+$venvPath = Join-Path $repoRoot ".venv"
+$venvPython = Join-Path $venvPath "Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $venvPython)) {
+    $venvArgs = @() + $pythonPrefix + @("-m", "venv", ".venv")
+    & $pythonExe @venvArgs
+    Assert-LastExitCode "Virtual environment creation"
+    Write-Host "Created .venv."
+} else {
+    Write-Host "Existing .venv preserved."
+}
+
+& $venvPython -m pip install -r requirements-dev.txt
+Assert-LastExitCode "Python dependency installation"
+
+& $pnpmCommand.Source install --frozen-lockfile
+Assert-LastExitCode "JavaScript dependency installation"
+
+if (-not $SkipSmoke) {
+    & $venvPython scripts/release-provider-smoke.py --provider openai --no-key-only
+    Assert-LastExitCode "No-key readiness check"
+}
+
+Write-Host ""
+Write-Host "Setup complete. No paid provider model call was made by this bootstrap."
+Write-Host "Start the API in terminal 1:  .\scripts\dev-api.ps1"
+Write-Host "Start the web app in terminal 2: .\scripts\dev-web.ps1"
+Write-Host "Then open http://localhost:3000"


### PR DESCRIPTION
## Why

The current Windows tester path still requires several manual setup steps before the no-key readiness check can run. That friction makes genuine first-run validation harder than necessary.

## Changes

- add `scripts/setup-windows.ps1` for a guarded one-command project bootstrap;
- validate Python 3.11+, Node.js 20+, pnpm 11, and required repository files before changing anything;
- preserve an existing `.env` and `.venv` instead of overwriting them;
- create `.env` from the non-secret example only when missing;
- install Python/JavaScript repository dependencies and run the no-key smoke by default;
- add `-CheckOnly` for non-mutating prerequisite validation and `-SkipSmoke` for maintainers who explicitly need it;
- document the zero-cost Windows path;
- exercise the bootstrap end to end on the real Windows Platform Readiness runner.

## Safety

The bootstrap does not install system runtimes, does not add provider credentials, and the default smoke path strips provider credentials before starting its temporary runtime and makes no billable model call.