### PR TITLE
feat: add localhost-only Docker Compose first-run path

### DIFF
--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "Dockerfile"
+      - "compose.yaml"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -19,6 +20,7 @@ on:
     branches: [main]
     paths:
       - "Dockerfile"
+      - "compose.yaml"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -65,32 +67,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-      - name: Build production image
-        run: docker build --tag personal-ai-os:ci .
-      - name: Start production image and verify health
+      - name: Validate Compose configuration
+        run: docker compose config
+      - name: Build Compose application
+        run: docker compose build
+      - name: Start Compose application and verify health
         shell: bash
         run: |
-          docker run -d \
-            --name personal-ai-os-ci \
-            -p 127.0.0.1:18080:8080 \
-            -e PERSONAL_AI_OS_REQUIRE_AUTH=false \
-            personal-ai-os:ci
+          docker compose up -d
 
           for attempt in $(seq 1 40); do
-            if curl --fail --silent --show-error http://127.0.0.1:18080/health; then
+            if curl --fail --silent --show-error http://127.0.0.1:8080/health; then
               echo
               exit 0
             fi
             sleep 2
           done
 
-          echo "Container did not become healthy" >&2
-          docker logs personal-ai-os-ci >&2 || true
+          echo "Compose application did not become healthy" >&2
+          docker compose ps >&2 || true
+          docker compose logs >&2 || true
           exit 1
       - name: Verify production mobile/PWA readiness
         shell: pwsh
         run: |
-          ./scripts/check-mobile-readiness.ps1 -BaseUrl "http://127.0.0.1:18080" -AllowInsecureLocalhost
-      - name: Clean up container
+          ./scripts/check-mobile-readiness.ps1 -BaseUrl "http://127.0.0.1:8080" -AllowInsecureLocalhost
+      - name: Clean up Compose application
         if: always()
-        run: docker rm -f personal-ai-os-ci >/dev/null 2>&1 || true
+        run: docker compose down -v --remove-orphans

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,28 @@
+services:
+  personal-ai-os:
+    build:
+      context: .
+    init: true
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      PERSONAL_AI_OS_DATA_DIR: /data
+      PERSONAL_AI_OS_DEPLOYMENT_MODE: community
+      PERSONAL_AI_OS_PLAN: community
+      PERSONAL_AI_OS_TENANT_ID: local
+      PERSONAL_AI_OS_ACTOR_ID: local-owner
+      PERSONAL_AI_OS_REQUIRE_AUTH: "false"
+      PERSONAL_AI_OS_OPENAI_API_KEY: "${PERSONAL_AI_OS_OPENAI_API_KEY:-}"
+      PERSONAL_AI_OS_ANTHROPIC_API_KEY: "${PERSONAL_AI_OS_ANTHROPIC_API_KEY:-}"
+      PERSONAL_AI_OS_REALTIME_API_KEY: "${PERSONAL_AI_OS_REALTIME_API_KEY:-}"
+      PERSONAL_AI_OS_OLLAMA_ENABLED: "${PERSONAL_AI_OS_OLLAMA_ENABLED:-false}"
+      PERSONAL_AI_OS_OLLAMA_ENDPOINT: "${PERSONAL_AI_OS_OLLAMA_ENDPOINT:-http://host.docker.internal:11434/v1/chat/completions}"
+      PERSONAL_AI_OS_DEFAULT_PROVIDER: "${PERSONAL_AI_OS_DEFAULT_PROVIDER:-openai}"
+      PERSONAL_AI_OS_DEFAULT_MODEL: "${PERSONAL_AI_OS_DEFAULT_MODEL:-gpt-5.1}"
+    volumes:
+      - personal_ai_os_data:/data
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  personal_ai_os_data:

--- a/docs/try-without-api.md
+++ b/docs/try-without-api.md
@@ -15,6 +15,37 @@ The zero-cost readiness check starts the API against a temporary data directory 
 
 It does **not** certify a real provider connection, model response, or provider-backed conversation. Those remain part of the separate release smoke gate.
 
+## Docker: lowest-friction local start
+
+If Docker Desktop (or Docker Engine with Compose) is already installed, no local Python, Node.js, or pnpm setup is required.
+
+From a fresh checkout, run:
+
+```bash
+docker compose up --build -d
+```
+
+Then open `http://127.0.0.1:8080`.
+
+The provided Compose configuration binds the application to `127.0.0.1` only, stores runtime data in a named Docker volume, and starts in community mode with authentication disabled for local use. On a fresh checkout with no provider credential configured, starting the container makes no billable model call.
+
+Check container state and logs with:
+
+```bash
+docker compose ps
+docker compose logs
+```
+
+Stop the application while preserving its named data volume with:
+
+```bash
+docker compose down
+```
+
+Use `docker compose down -v` only when you intentionally want to delete the local Compose data volume as well.
+
+Do not change the port binding to a public interface while authentication is disabled. Public deployments require the documented access controls and trusted HTTPS boundary.
+
 ## Windows: prepare a fresh checkout in one command
 
 Prerequisites are Python 3.11+, Node.js 20+, and pnpm 11. The bootstrap does not install system runtimes, does not add a provider credential, and never overwrites an existing `.env` file.
@@ -59,7 +90,7 @@ Expected result: the command exits successfully and prints PASS messages for the
 
 If the command fails, the no-key UI is confusing, setup steps are unclear, or you find a reproducible bug, open the **Early tester feedback** issue form or add sanitized feedback to Issue #7.
 
-Please include your OS, Python/Node versions, the exact step that failed, and a minimal reproduction. Never include API keys, `.env` contents, authorization headers, cookies, private conversations, runtime databases, or private project data.
+Please include your OS, Python/Node versions when applicable, the exact step that failed, and a minimal reproduction. Never include API keys, `.env` contents, authorization headers, cookies, private conversations, runtime databases, or private project data.
 
 ## Want to test the full provider path?
 


### PR DESCRIPTION
## Why

The production Dockerfile is already verified, but a new user still has to know the full build/run flags or prepare Python/Node locally. A Compose path gives users who already have Docker a single-command local start without weakening the public-deployment boundary.

## Changes

- add `compose.yaml` with a named persistent data volume and localhost-only `127.0.0.1:8080` binding;
- keep community mode/auth-disabled defaults explicitly local rather than exposing the service publicly;
- allow provider credentials to be supplied only through the user's environment/Compose interpolation without committing secrets;
- use `host.docker.internal` as the default optional Ollama endpoint for container-to-host local inference;
- document start, logs, normal shutdown, and intentional volume deletion;
- make Platform Readiness validate, build, start, health-check, mobile/PWA-check, and clean up the Compose application end to end.

## Safety

The default port is loopback-only. This PR does not claim the auth-disabled Compose profile is suitable for a public deployment, and the documentation explicitly warns against exposing it publicly.