### PR TITLE
docs: add real-world use evidence funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/real_world_use.yml
+++ b/.github/ISSUE_TEMPLATE/real_world_use.yml
@@ -1,5 +1,5 @@
 name: Real-world use
-about: Share a genuine Personal AI OS workflow, including failed or partial adoption
+description: Share a genuine Personal AI OS workflow, including failed or partial adoption
 labels: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/real_world_use.yml
+++ b/.github/ISSUE_TEMPLATE/real_world_use.yml
@@ -1,0 +1,83 @@
+name: Real-world use
+about: Share a genuine Personal AI OS workflow, including failed or partial adoption
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form only for genuine first-hand use. Successful use, failed attempts, partial adoption, and reasons you stopped are all useful. Do not submit synthetic testimonials, reciprocal promotion, or maintainer-authored adoption claims.
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, and Docker/source checkout as applicable.
+      placeholder: Windows 11 x64, Docker Desktop 4.x
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Tag, branch, or commit you actually tried.
+      placeholder: v0.2.0 or commit SHA
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow you tried
+      description: What persistent AI work were you trying to do, and why did you try Personal AI OS for it?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Product surfaces actually used
+      options:
+        - label: Chat / provider adapters
+        - label: Projects / persistent project state
+        - label: Reviewed Memory
+        - label: MCP tools / connectors
+        - label: Execution history / audit views
+        - label: Local Ollama
+        - label: Mobile / PWA shell
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What worked and what blocked continued use?
+      description: Negative feedback is valid. Please separate what worked from what did not.
+    validations:
+      required: true
+
+  - type: textarea
+    id: next_change
+    attributes:
+      label: Highest-value next change
+      description: What single improvement would most increase the chance you keep using or contributing to the project?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you consider a focused contribution?
+      options:
+        - Yes, a documentation fix
+        - Yes, a bug report or code PR
+        - Maybe
+        - No
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy acknowledgement
+      options:
+        - label: I have not included API keys, .env contents, authorization headers, cookies, private conversations, runtime databases, secret-bearing logs, uploads/backups, or private project data.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,25 @@
 Thank you for helping improve Personal AI OS. Contributions should keep the core
 general-purpose, local-first, auditable, and safe for private user data.
 
+## Share genuine use
+
+Independent first-hand use is useful even when the outcome is negative. If you tried Personal AI OS
+for a real workflow, use [Issue #55](https://github.com/sui-ni2/personal-ai-os/issues/55) or the
+`Real-world use` issue form to describe what you attempted, what worked, and what blocked continued
+use. See [Real-world use and external evidence](docs/real-world-use.md) for the evidence and privacy
+boundary.
+
+Do not create synthetic testimonials, duplicate accounts, reciprocal engagement, or generated
+feedback. CI activity, repository settings, and maintainer dogfooding are maintenance evidence, not
+independent adoption.
+
 ## Good first contributions
 
 If you are new to the project, the highest-value contribution is to try a fresh install and report
 real setup or first-chat friction in [Issue #7](https://github.com/sui-ni2/personal-ai-os/issues/7).
-Small documentation corrections and focused bug fixes are also welcome. Please do not create
-synthetic feedback or test data that could be mistaken for real user adoption.
+Windows testers can use [Issue #15](https://github.com/sui-ni2/personal-ai-os/issues/15); macOS/Linux
+Docker testers can use [Issue #56](https://github.com/sui-ni2/personal-ai-os/issues/56). Small
+documentation corrections and focused bug fixes are also welcome.
 
 You do **not** need a paid provider API key to verify the safe first-run path.
 

--- a/docs/real-world-use.md
+++ b/docs/real-world-use.md
@@ -1,0 +1,46 @@
+# Real-world use and external evidence
+
+Personal AI OS is looking for first-hand evidence about whether the project is useful outside the maintainer's own workflow. The purpose of this page is to make that evidence easy to submit and difficult to misrepresent.
+
+## Useful evidence
+
+The strongest public evidence is reproducible and attributable to an independent user or contributor. Examples include:
+
+- a fresh-install report with the tested OS/runtime and version;
+- a real workflow description explaining what the user attempted and what happened;
+- a bug report found during genuine use;
+- a focused pull request from an external contributor;
+- a public follow-up showing that reported friction was fixed and independently re-tested.
+
+Failed adoption is still useful evidence. A report explaining why someone stopped using the project can be more actionable than an unqualified positive comment.
+
+## What does not count
+
+The project does not treat the following as adoption evidence:
+
+- maintainer-authored testimonials or self-replies;
+- synthetic or duplicate accounts;
+- paid, reciprocal, or coordinated stars/forks/comments;
+- generated testimonials or placeholder feedback;
+- CI runs, release automation, Dependabot activity, or repository settings by themselves;
+- claims that cannot be tied to a real public report or contribution.
+
+Repository maintenance and automated verification are still valuable, but they are maintenance evidence rather than external adoption.
+
+## How to contribute evidence
+
+Use one of these paths:
+
+1. **Installation / first-run testing:** Issue #7 or the `Early tester feedback` issue form.
+2. **Windows fresh-install verification:** Issue #15.
+3. **macOS/Linux Docker verification:** Issue #56.
+4. **Ongoing or attempted real workflow:** Issue #55 or the `Real-world use` issue form.
+5. **Code or documentation contribution:** open a focused pull request following `CONTRIBUTING.md`.
+
+## Privacy boundary
+
+Never post API keys, `.env` contents, authorization headers, cookies, private conversations, runtime databases, secret-bearing logs, uploads/backups, or private project data. A sanitized description of the workflow and outcome is sufficient.
+
+## Maintainer handling
+
+Maintainers should preserve unfavorable but good-faith reports, distinguish independent evidence from first-party dogfooding, and link fixes back to the original external report when possible. Public metrics may be summarized later, but only from verifiable repository evidence and with the observation date stated.


### PR DESCRIPTION
## Why

The repository already has strong maintainer/CI evidence, but external adoption is a separate question. This change creates a clear, privacy-safe path for genuine first-hand use reports without manufacturing testimonials or treating maintenance activity as adoption.

## Changes

- add a `Real-world use` issue form for independent workflow reports, including failed or partial adoption;
- document what counts and does not count as external usage evidence;
- surface the new use-case path plus the Windows and macOS/Linux tester tasks in `CONTRIBUTING.md`;
- explicitly reject synthetic accounts, reciprocal engagement, generated testimonials, and maintainer dogfooding as independent adoption evidence.

Related public funnels: #55 and #56.

Documentation/issue-routing only. No runtime behavior or adoption claim is changed.