### PR TITLE
feat: verify release evidence fail-closed before tagging

### DIFF
--- a/apps/api/tests/test_release_evidence_verifier.py
+++ b/apps/api/tests/test_release_evidence_verifier.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.release_evidence_verifier import REQUIRED_CHECKS, verify_release_evidence
+
+
+SHA = "a" * 40
+AS_OF = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+
+
+def _check(name: str, **overrides: object) -> dict[str, object]:
+    check: dict[str, object] = {
+        "name": name,
+        "conclusion": "success",
+        "head_sha": SHA,
+        "completed_at": "2026-08-18T11:00:00Z",
+        "url": f"https://github.com/example/repo/actions/runs/{name.replace(' ', '-')}",
+    }
+    check.update(overrides)
+    return check
+
+
+def _payload(checks: list[dict[str, object]] | None = None, *, commit_sha: str = SHA):
+    return {
+        "commit_sha": commit_sha,
+        "checks": checks if checks is not None else [_check(name) for name in REQUIRED_CHECKS],
+    }
+
+
+def _codes(result) -> set[tuple[str, str | None]]:
+    return {(blocker.code, blocker.check) for blocker in result.blockers}
+
+
+def test_complete_fresh_same_commit_bundle_is_ready() -> None:
+    result = verify_release_evidence(_payload(), expected_sha=SHA, as_of=AS_OF)
+
+    assert result.ready_to_tag is True
+    assert result.decision == "ready_to_tag"
+    assert result.blockers == ()
+
+
+def test_missing_required_check_blocks_release() -> None:
+    checks = [_check(name) for name in REQUIRED_CHECKS if name != "CodeQL"]
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert result.ready_to_tag is False
+    assert ("missing_check", "CodeQL") in _codes(result)
+
+
+def test_skipped_release_smoke_blocks_release() -> None:
+    checks = [
+        _check(name, conclusion="skipped") if name == "Release provider smoke" else _check(name)
+        for name in REQUIRED_CHECKS
+    ]
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert ("check_not_successful", "Release provider smoke") in _codes(result)
+    assert result.decision == "blocked"
+
+
+def test_check_from_different_commit_blocks_release() -> None:
+    checks = [
+        _check(name, head_sha="b" * 40) if name == "CI" else _check(name)
+        for name in REQUIRED_CHECKS
+    ]
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert ("check_commit_mismatch", "CI") in _codes(result)
+
+
+def test_stale_check_blocks_release() -> None:
+    checks = [
+        _check(name, completed_at="2026-08-15T00:00:00Z") if name == "Platform Readiness" else _check(name)
+        for name in REQUIRED_CHECKS
+    ]
+    result = verify_release_evidence(
+        _payload(checks),
+        expected_sha=SHA,
+        as_of=AS_OF,
+        max_age_hours=48,
+    )
+
+    assert ("stale_check", "Platform Readiness") in _codes(result)
+
+
+def test_duplicate_required_check_blocks_release() -> None:
+    checks = [_check(name) for name in REQUIRED_CHECKS]
+    checks.append(_check("CodeQL"))
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert ("duplicate_check", "CodeQL") in _codes(result)
+
+
+def test_missing_audit_url_blocks_release() -> None:
+    checks = [
+        _check(name, url="") if name == "Dependency Review" else _check(name)
+        for name in REQUIRED_CHECKS
+    ]
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert ("missing_source_url", "Dependency Review") in _codes(result)
+
+
+def test_bundle_commit_mismatch_blocks_release() -> None:
+    result = verify_release_evidence(
+        _payload(commit_sha="b" * 40),
+        expected_sha=SHA,
+        as_of=AS_OF,
+    )
+
+    assert ("bundle_commit_mismatch", None) in _codes(result)
+
+
+def test_future_check_blocks_release() -> None:
+    checks = [
+        _check(name, completed_at="2026-08-18T13:00:00Z") if name == "CI" else _check(name)
+        for name in REQUIRED_CHECKS
+    ]
+    result = verify_release_evidence(_payload(checks), expected_sha=SHA, as_of=AS_OF)
+
+    assert ("future_check", "CI") in _codes(result)
+
+
+def test_expected_sha_requires_full_commit_sha() -> None:
+    with pytest.raises(ValueError, match="40-character"):
+        verify_release_evidence(_payload(), expected_sha="abc123", as_of=AS_OF)

--- a/docs/release-evidence.md
+++ b/docs/release-evidence.md
@@ -1,0 +1,98 @@
+# Release evidence verification
+
+Stable-release readiness is an evidence question, not a successful-command question. The verifier in
+`scripts/release_evidence_verifier.py` checks a collected evidence bundle and refuses to report
+`ready_to_tag` when required evidence is missing, stale, non-successful, unauditable, or attached to
+a different commit.
+
+It **does not** fetch GitHub data, create a tag, publish a release, or bypass repository rules. Evidence
+collection remains a separate step so the final decision can be reproduced from a small JSON file.
+
+## Required gates
+
+A release bundle must contain exactly one successful result for each gate:
+
+- `CI`
+- `CodeQL`
+- `Dependency Review`
+- `Platform Readiness`
+- `Release provider smoke`
+
+Every gate must reference the exact expected full commit SHA, include an HTTPS source URL, and include
+an ISO-8601 completion timestamp. By default, evidence older than 48 hours is blocked; the age window
+can be changed explicitly for a particular release process.
+
+## Evidence format
+
+```json
+{
+  "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+  "checks": [
+    {
+      "name": "CI",
+      "conclusion": "success",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "completed_at": "2026-08-18T11:00:00Z",
+      "url": "https://github.com/owner/repo/actions/runs/123"
+    },
+    {
+      "name": "CodeQL",
+      "conclusion": "success",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "completed_at": "2026-08-18T11:05:00Z",
+      "url": "https://github.com/owner/repo/actions/runs/124"
+    },
+    {
+      "name": "Dependency Review",
+      "conclusion": "success",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "completed_at": "2026-08-18T11:06:00Z",
+      "url": "https://github.com/owner/repo/actions/runs/125"
+    },
+    {
+      "name": "Platform Readiness",
+      "conclusion": "success",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "completed_at": "2026-08-18T11:10:00Z",
+      "url": "https://github.com/owner/repo/actions/runs/126"
+    },
+    {
+      "name": "Release provider smoke",
+      "conclusion": "success",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "completed_at": "2026-08-18T11:12:00Z",
+      "url": "https://github.com/owner/repo/actions/runs/127"
+    }
+  ]
+}
+```
+
+A normal pull-request run commonly reports `Release provider smoke` as `skipped`. That is expected for
+an ordinary PR but **does not satisfy a stable-release bundle**. The verifier is intentionally stricter
+than ordinary PR merge readiness.
+
+## Run
+
+```bash
+python scripts/release_evidence_verifier.py evidence.json \
+  --expected-sha 0123456789abcdef0123456789abcdef01234567
+```
+
+For reproducible review or tests, pin the observation time:
+
+```bash
+python scripts/release_evidence_verifier.py evidence.json \
+  --expected-sha 0123456789abcdef0123456789abcdef01234567 \
+  --as-of 2026-08-18T12:00:00Z \
+  --max-age-hours 48
+```
+
+Exit status is `0` only when the bundle is ready. A blocked bundle exits `1`; malformed input or invalid
+arguments exit `2`.
+
+## Fail-closed boundary
+
+The tool only verifies supplied evidence. It cannot prove that a URL is truthful merely because it is
+HTTPS, cannot infer a missing check from another check, and cannot treat a retry as proof that previous
+failure evidence was irrelevant. Automated collection should preserve the original GitHub run/job URL
+and exact commit association so a maintainer can audit the decision independently.

--- a/scripts/release_evidence_verifier.py
+++ b/scripts/release_evidence_verifier.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+
+REQUIRED_CHECKS: tuple[str, ...] = (
+    "CI",
+    "CodeQL",
+    "Dependency Review",
+    "Platform Readiness",
+    "Release provider smoke",
+)
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.I)
+
+
+@dataclass(frozen=True)
+class Blocker:
+    code: str
+    check: str | None
+    detail: str
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    ready_to_tag: bool
+    decision: str
+    expected_sha: str
+    as_of: str
+    max_age_hours: float
+    required_checks: tuple[str, ...]
+    blockers: tuple[Blocker, ...]
+
+
+def _parse_time(value: str, *, field: str) -> datetime:
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def verify_release_evidence(
+    payload: dict[str, Any],
+    *,
+    expected_sha: str,
+    as_of: datetime,
+    max_age_hours: float = 48.0,
+) -> VerificationResult:
+    if not _SHA_RE.fullmatch(expected_sha):
+        raise ValueError("expected_sha must be a full 40-character hexadecimal commit SHA")
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must include a timezone")
+    if max_age_hours <= 0:
+        raise ValueError("max_age_hours must be positive")
+
+    as_of_utc = as_of.astimezone(timezone.utc)
+    max_age = timedelta(hours=max_age_hours)
+    blockers: list[Blocker] = []
+
+    declared_sha = payload.get("commit_sha")
+    if declared_sha != expected_sha:
+        blockers.append(
+            Blocker(
+                code="bundle_commit_mismatch",
+                check=None,
+                detail=f"bundle commit_sha is {declared_sha!r}, expected {expected_sha}",
+            )
+        )
+
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        checks = []
+        blockers.append(
+            Blocker(
+                code="invalid_checks",
+                check=None,
+                detail="checks must be a list",
+            )
+        )
+
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for item in checks:
+        if not isinstance(item, dict):
+            blockers.append(
+                Blocker(
+                    code="invalid_check_entry",
+                    check=None,
+                    detail="every checks entry must be an object",
+                )
+            )
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            blockers.append(
+                Blocker(
+                    code="invalid_check_name",
+                    check=None,
+                    detail="every check must have a non-empty name",
+                )
+            )
+            continue
+        by_name.setdefault(name, []).append(item)
+
+    for name in REQUIRED_CHECKS:
+        entries = by_name.get(name, [])
+        if not entries:
+            blockers.append(
+                Blocker(code="missing_check", check=name, detail="required check is missing")
+            )
+            continue
+        if len(entries) != 1:
+            blockers.append(
+                Blocker(
+                    code="duplicate_check",
+                    check=name,
+                    detail=f"required check appears {len(entries)} times",
+                )
+            )
+            continue
+
+        entry = entries[0]
+        conclusion = entry.get("conclusion")
+        if conclusion != "success":
+            blockers.append(
+                Blocker(
+                    code="check_not_successful",
+                    check=name,
+                    detail=f"conclusion is {conclusion!r}, expected 'success'",
+                )
+            )
+
+        head_sha = entry.get("head_sha")
+        if head_sha != expected_sha:
+            blockers.append(
+                Blocker(
+                    code="check_commit_mismatch",
+                    check=name,
+                    detail=f"head_sha is {head_sha!r}, expected {expected_sha}",
+                )
+            )
+
+        source_url = entry.get("url")
+        if not isinstance(source_url, str) or not source_url.startswith("https://"):
+            blockers.append(
+                Blocker(
+                    code="missing_source_url",
+                    check=name,
+                    detail="an HTTPS source URL is required for auditability",
+                )
+            )
+
+        completed_at_raw = entry.get("completed_at")
+        if not isinstance(completed_at_raw, str):
+            blockers.append(
+                Blocker(
+                    code="missing_completed_at",
+                    check=name,
+                    detail="completed_at is required",
+                )
+            )
+            continue
+
+        try:
+            completed_at = _parse_time(completed_at_raw, field=f"{name}.completed_at")
+        except ValueError as exc:
+            blockers.append(
+                Blocker(code="invalid_completed_at", check=name, detail=str(exc))
+            )
+            continue
+
+        if completed_at > as_of_utc:
+            blockers.append(
+                Blocker(
+                    code="future_check",
+                    check=name,
+                    detail=f"completed_at {_iso(completed_at)} is after as_of {_iso(as_of_utc)}",
+                )
+            )
+        elif as_of_utc - completed_at > max_age:
+            blockers.append(
+                Blocker(
+                    code="stale_check",
+                    check=name,
+                    detail=(
+                        f"completed_at {_iso(completed_at)} is older than "
+                        f"{max_age_hours:g} hours at {_iso(as_of_utc)}"
+                    ),
+                )
+            )
+
+    result_blockers = tuple(blockers)
+    return VerificationResult(
+        ready_to_tag=not result_blockers,
+        decision="ready_to_tag" if not result_blockers else "blocked",
+        expected_sha=expected_sha,
+        as_of=_iso(as_of_utc),
+        max_age_hours=max_age_hours,
+        required_checks=REQUIRED_CHECKS,
+        blockers=result_blockers,
+    )
+
+
+def _read_payload(path: str) -> dict[str, Any]:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("evidence payload must be a JSON object")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a release evidence bundle without creating a tag or release. "
+            "Missing, stale, non-successful, or wrong-commit evidence blocks readiness."
+        )
+    )
+    parser.add_argument("evidence", help="Evidence JSON path, or '-' for stdin")
+    parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--as-of", default=None, help="ISO-8601 time; defaults to current UTC")
+    parser.add_argument("--max-age-hours", type=float, default=48.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = _read_payload(args.evidence)
+        as_of = (
+            _parse_time(args.as_of, field="as_of")
+            if args.as_of
+            else datetime.now(timezone.utc)
+        )
+        result = verify_release_evidence(
+            payload,
+            expected_sha=args.expected_sha,
+            as_of=as_of,
+            max_age_hours=args.max_age_hours,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    print(json.dumps(asdict(result), ensure_ascii=False, sort_keys=True))
+    return 0 if result.ready_to_tag else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Issue #59 calls for an auditable release-evidence bundle. Stable-release claims should fail closed when a required gate is missing, stale, non-successful, unauditable, or belongs to a different commit.

## Changes

- add `scripts/release_evidence_verifier.py`;
- require CI, CodeQL, Dependency Review, Platform Readiness, and Release provider smoke evidence;
- require every gate to report `success` for the exact expected 40-character commit SHA;
- require an HTTPS source URL and completion timestamp for auditability;
- block stale or future-dated evidence using a configurable age window;
- reject duplicate required gates and bundle/commit mismatches;
- emit `ready_to_tag` only when there are zero blockers;
- do not create tags, releases, or modify GitHub state;
- add ten pytest cases covering ready, missing, skipped, wrong-commit, stale, duplicate, missing-source, bundle mismatch, future timestamp, and invalid SHA cases.

This implements the release-evidence verification slice of #59; collection/orchestration can remain separate so the deterministic verifier stays auditable.