### PR TITLE
feat: triage tester feedback without claiming adoption

### DIFF
--- a/apps/api/tests/test_tester_feedback_triage.py
+++ b/apps/api/tests/test_tester_feedback_triage.py
@@ -1,0 +1,87 @@
+import pytest
+
+from scripts.tester_feedback_triage import triage_feedback
+
+
+def test_setup_failure_routes_to_setup_friction() -> None:
+    result = triage_feedback(
+        "Fresh clone setup failed on Ubuntu after docker compose up --build -d."
+    )
+
+    assert result.category == "setup_friction"
+    assert result.needs_reproduction is True
+    assert result.adoption_evidence is False
+    assert result.decision == "needs_review"
+
+
+def test_documentation_gap_is_distinct_from_product_bug() -> None:
+    result = triage_feedback("The README instructions are unclear around the no-key startup path.")
+
+    assert result.category == "documentation_gap"
+    assert result.needs_reproduction is False
+
+
+def test_product_bug_requests_reproduction() -> None:
+    result = triage_feedback("After restart the project memory is lost and the workflow is broken.")
+
+    assert result.category == "product_bug"
+    assert result.needs_reproduction is True
+
+
+def test_feature_request_is_not_adoption_evidence() -> None:
+    result = triage_feedback("Feature request: please add support for another local provider.")
+
+    assert result.category == "feature_request"
+    assert result.adoption_evidence is False
+    assert result.needs_maintainer_review is True
+
+
+def test_use_outcome_still_requires_review_before_adoption_claim() -> None:
+    result = triage_feedback("I tested the memory workflow for a project and it worked for my use case.")
+
+    assert result.category == "use_outcome"
+    assert result.adoption_evidence is False
+    assert result.decision == "needs_review"
+
+
+def test_unknown_feedback_fails_closed() -> None:
+    result = triage_feedback("Interesting project, thanks for sharing.")
+
+    assert result.category == "inconclusive"
+    assert result.confidence == "low"
+    assert result.adoption_evidence is False
+    assert result.evidence is None
+
+
+def test_secret_shapes_are_redacted_from_evidence() -> None:
+    result = triage_feedback(
+        "The setup failed with Authorization: Bearer secret-token ghp_1234567890abcdef sk-abcdefghijk"
+    )
+
+    assert result.evidence is not None
+    assert "secret-token" not in result.evidence
+    assert "ghp_1234567890abcdef" not in result.evidence
+    assert "sk-abcdefghijk" not in result.evidence
+    assert result.privacy_redactions_applied is True
+
+
+def test_env_secret_shape_is_redacted() -> None:
+    result = triage_feedback("Setup error after OPENAI_KEY=super-secret-value was configured.")
+
+    assert result.evidence is not None
+    assert "super-secret-value" not in result.evidence
+    assert result.privacy_redactions_applied is True
+
+
+def test_https_source_url_is_preserved() -> None:
+    result = triage_feedback(
+        "The guide is confusing for Docker setup.",
+        source_url="https://github.com/example/repo/issues/1",
+    )
+
+    assert result.source_url == "https://github.com/example/repo/issues/1"
+
+
+def test_non_https_source_url_is_rejected() -> None:
+    with pytest.raises(ValueError, match="HTTPS"):
+        triage_feedback("Setup failed.", source_url="http://example.com/report")

--- a/scripts/tester_feedback_triage.py
+++ b/scripts/tester_feedback_triage.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import re
+from pathlib import Path
+import sys
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class TriageRule:
+    rule_id: str
+    category: str
+    patterns: tuple[re.Pattern[str], ...]
+
+
+@dataclass(frozen=True)
+class TriageResult:
+    category: str
+    confidence: str
+    decision: str
+    adoption_evidence: bool
+    rule_id: str | None
+    evidence: str | None
+    needs_reproduction: bool
+    needs_maintainer_review: bool
+    privacy_redactions_applied: bool
+    source_url: str | None = None
+
+
+RULES: tuple[TriageRule, ...] = (
+    TriageRule(
+        rule_id="install-or-startup-friction",
+        category="setup_friction",
+        patterns=(
+            re.compile(r"(?:install|setup|bootstrap|docker compose|fresh clone).*(?:fail|error|stuck|unclear|cannot|can't)", re.I),
+            re.compile(r"(?:fail|error|stuck|unclear|cannot|can't).*(?:install|setup|bootstrap|docker compose|fresh clone)", re.I),
+        ),
+    ),
+    TriageRule(
+        rule_id="documentation-gap",
+        category="documentation_gap",
+        patterns=(
+            re.compile(r"(?:docs?|readme|instruction|guide).*(?:wrong|missing|unclear|outdated|confusing)", re.I),
+            re.compile(r"(?:wrong|missing|unclear|outdated|confusing).*(?:docs?|readme|instruction|guide)", re.I),
+        ),
+    ),
+    TriageRule(
+        rule_id="reproducible-product-bug",
+        category="product_bug",
+        patterns=(
+            re.compile(r"(?:crash|traceback|500|exception|broken|does not work|doesn't work)", re.I),
+            re.compile(r"(?:restart|persist|memory|chat|provider|mcp|project).*(?:lost|fails?|broken|error)", re.I),
+        ),
+    ),
+    TriageRule(
+        rule_id="feature-request",
+        category="feature_request",
+        patterns=(
+            re.compile(r"(?:feature request|would be useful|please add|could you add|support for)", re.I),
+        ),
+    ),
+    TriageRule(
+        rule_id="positive-or-negative-use-outcome",
+        category="use_outcome",
+        patterns=(
+            re.compile(r"(?:used|tried|tested|running|worked|stopped using|kept using).*(?:workflow|project|chat|memory|mcp|provider|ollama)", re.I),
+            re.compile(r"(?:workflow|project|chat|memory|mcp|provider|ollama).*(?:worked|failed|useful|blocked|stopped)", re.I),
+        ),
+    ),
+)
+
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)(authorization\s*:\s*(?:bearer|basic)\s+)[^\s]+"), r"\1[REDACTED]"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), "[REDACTED_API_KEY]"),
+    (re.compile(r"(?i)(?:OPENAI|ANTHROPIC|API)_KEY\s*=\s*[^\s]+"), "[REDACTED_ENV_SECRET]"),
+)
+
+
+def _sanitize(text: str) -> tuple[str, bool]:
+    sanitized = text.strip()
+    changed = False
+    for pattern, replacement in _SECRET_PATTERNS:
+        updated = pattern.sub(replacement, sanitized)
+        if updated != sanitized:
+            changed = True
+            sanitized = updated
+    return sanitized[:700], changed
+
+
+def _lines(text: str) -> Iterable[str]:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            yield stripped
+
+
+def triage_feedback(text: str, *, source_url: str | None = None) -> TriageResult:
+    if source_url is not None and not source_url.startswith("https://"):
+        raise ValueError("source_url must be HTTPS when supplied")
+
+    lines = tuple(_lines(text))
+    for rule in RULES:
+        for line in lines:
+            if any(pattern.search(line) for pattern in rule.patterns):
+                evidence, redacted = _sanitize(line)
+                needs_reproduction = rule.category in ("setup_friction", "product_bug")
+                return TriageResult(
+                    category=rule.category,
+                    confidence="medium",
+                    decision="needs_review",
+                    adoption_evidence=False,
+                    rule_id=rule.rule_id,
+                    evidence=evidence,
+                    needs_reproduction=needs_reproduction,
+                    needs_maintainer_review=True,
+                    privacy_redactions_applied=redacted,
+                    source_url=source_url,
+                )
+
+    _, redacted = _sanitize(text)
+    return TriageResult(
+        category="inconclusive",
+        confidence="low",
+        decision="needs_review",
+        adoption_evidence=False,
+        rule_id=None,
+        evidence=None,
+        needs_reproduction=False,
+        needs_maintainer_review=True,
+        privacy_redactions_applied=redacted,
+        source_url=source_url,
+    )
+
+
+def _read_text(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Classify sanitized first-hand tester feedback for maintainer triage. "
+            "The result never marks a report as verified adoption evidence."
+        )
+    )
+    parser.add_argument("feedback", help="Feedback text path, or '-' for stdin")
+    parser.add_argument("--source-url", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        text = _read_text(args.feedback)
+        result = triage_feedback(text, source_url=args.source_url)
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    print(json.dumps(asdict(result), ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Issue #59's remaining maintenance slice is external tester feedback triage. Genuine negative, failed, or partial-use reports should be routed consistently without converting a comment into a verified adoption claim.

## Changes

- add `scripts/tester_feedback_triage.py`;
- classify first-hand report text into setup friction, documentation gap, product bug, feature request, use outcome, or inconclusive;
- request reproduction for setup/product failures;
- redact common authorization/GitHub/OpenAI/environment secret shapes from emitted evidence;
- preserve an optional HTTPS source URL for auditability;
- always emit `decision=needs_review`, `needs_maintainer_review=true`, and `adoption_evidence=false`;
- add ten pytest cases covering each route, fail-closed unknowns, privacy redaction, and source URL validation.

The tool does not read or write GitHub issues, close reports, generate testimonials, or count adoption. Human review and the repository's external-evidence policy remain authoritative.