### PR TITLE
ci: verify hosted vinext build in platform readiness

### DIFF
--- a/.github/workflows/platform-readiness.yml
+++ b/.github/workflows/platform-readiness.yml
@@ -12,6 +12,7 @@ on:
       - "requirements-*.txt"
       - "apps/**"
       - "packages/**"
+      - "scripts/build-hosted.mjs"
       - "scripts/release-provider-smoke.py"
       - "scripts/check-mobile-readiness.ps1"
       - "scripts/setup-windows.ps1"
@@ -27,6 +28,7 @@ on:
       - "requirements-*.txt"
       - "apps/**"
       - "packages/**"
+      - "scripts/build-hosted.mjs"
       - "scripts/release-provider-smoke.py"
       - "scripts/check-mobile-readiness.ps1"
       - "scripts/setup-windows.ps1"
@@ -60,6 +62,31 @@ jobs:
           cache: pnpm
       - name: Verify Windows first-run bootstrap end to end
         run: ./scripts/setup-windows.ps1
+
+  hosted-build:
+    name: Hosted vinext build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.16.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build hosted vinext output
+        run: pnpm build
+      - name: Verify hosted output contract
+        shell: bash
+        run: |
+          test -f dist/server/index.js
+          test -f dist/.openai/hosting.json
 
   container:
     name: Container build, health, and mobile shell


### PR DESCRIPTION
## Why

The repository's standard frontend CI verifies the Next.js build, while Platform Readiness verifies Windows bootstrap and the Docker/PWA path. The actual hosted/vinext output path was not exercised, so Cloudflare/Vite compatibility changes could pass the existing gates without testing the surface they affect.

## Changes

- add `scripts/build-hosted.mjs` to Platform Readiness path triggers;
- add a `Hosted vinext build` job with the pinned pnpm/Node toolchain;
- run the real root `pnpm build` hosted-output path;
- verify the expected `dist/server/index.js` and copied `.openai/hosting.json` artifacts exist.

This is intended to make dependency changes such as #50 prove compatibility on the actual hosted build path rather than relying on the unrelated Next.js/Docker checks.