### PR TITLE
docs: surface reviewer verification and maintainer evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Repository maintenance is executable rather than release-note-only:
 
 Repository-admin settings that source-controlled CI cannot replace are tracked honestly in [`docs/repository-admin-checklist.md`](docs/repository-admin-checklist.md).
 
+## Verify the project quickly
+
+A reviewer can verify the no-key startup and privacy boundary without configuring a paid provider by following [Try Personal AI OS without an API key](docs/try-without-api.md). That proof is deliberately narrow: it covers clean startup, the expected runtime version, unconfigured-provider behavior, and secret redaction; it does not claim a real model response without a provider.
+
+For an auditable view of what has and has not been verified, see the [verification support matrix](docs/support-matrix.md), [maintainer evidence summary](docs/maintainer-evidence-summary.md), and [project evidence ledger](docs/evidence-ledger.md). CI, maintainer dogfooding, stars, and forks are kept separate from genuinely independent user evidence.
+
 ## What is runnable now
 
 - Next.js App Shell with Chat, Memory, Repository, Projects, and Settings views.

--- a/docs/maintainer-evidence-summary.md
+++ b/docs/maintainer-evidence-summary.md
@@ -1,0 +1,51 @@
+# Maintainer evidence summary
+
+**Observation date:** 2026-08-18
+
+Personal AI OS is a local-first, provider-neutral workspace for long-running AI work. Its core premise is that project state — conversations, reviewed memory, tools, execution history, and project context — should remain under the user's control while model providers remain replaceable execution engines.
+
+## What is runnable now
+
+The public community edition includes a Next.js application shell, FastAPI API, SQLite persistence, provider adapters for OpenAI and Anthropic plus an optional local Ollama adapter, restart-safe conversation history, an allowlisted MCP gateway, auditable execution events, project plugins, and an installable PWA shell. The current stable release line is `v0.2.0`.
+
+The repository also provides a zero-cost verification path that requires no paid provider key. That path verifies clean startup, the expected runtime version, unconfigured-provider behavior, and secret redaction without making a billable model call. See `docs/try-without-api.md`.
+
+## Maintainer responsibilities evidenced in the repository
+
+Public repository activity shows responsibility for:
+
+- product architecture and boundary decisions;
+- release preparation and version consistency;
+- backend/frontend tests and build checks;
+- CI, CodeQL, Dependency Review, Dependabot, and platform-readiness maintenance;
+- security/privacy documentation and repository hardening;
+- contributor and tester intake;
+- issue triage and follow-up fixes.
+
+Repository-admin hardening is tracked in Issue #39 and `docs/repository-admin-checklist.md`. Maintenance automation work is tracked separately and does not replace required checks or human review.
+
+## Release, security, and CI evidence
+
+The repository has a published `v0.2.0` release line and protected-main workflow. Normal pull requests run backend and frontend checks; CodeQL analyzes Python and JavaScript/TypeScript; Dependency Review fails closed on newly introduced high-severity dependency risk; Platform Readiness exercises the documented first-run paths; release candidates have an isolated provider-smoke gate.
+
+The project keeps secrets server-side, redacts secret-bearing audit fields, restricts MCP tool execution through allowlists, and documents private vulnerability reporting and privacy boundaries.
+
+## Independent adoption evidence
+
+Independent adoption is intentionally reported separately from maintainer activity and repository reach metrics.
+
+As of the observation date, the public evidence ledger does **not** claim a qualifying independent installation report, real-world-use report, or external pull request unless it can be linked directly to a public repository artifact. Stars and forks are recorded as reach signals only and are not treated as proof of successful use.
+
+See `docs/evidence-ledger.md`, `docs/real-world-use.md`, and `docs/support-matrix.md` for the current evidence state.
+
+## Current evidence gaps
+
+The most important remaining gaps are external rather than architectural:
+
+1. an independent fresh-install report with OS/runtime details;
+2. an independent real workflow report, including failed or partial adoption;
+3. an external bug fix, documentation fix, or focused pull request;
+4. independent verification of Windows and macOS/Linux setup paths;
+5. provider-backed first-chat and restart-persistence verification by a tester using their own supported provider configuration.
+
+These gaps must be closed by genuine third-party activity. Maintainer-authored testimonials, synthetic accounts, reciprocal engagement, paid stars/forks/comments, or generated feedback must not be used as substitutes.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,30 @@
+# Verification support matrix
+
+This matrix separates automated repository coverage, maintainer-side evidence, and genuinely independent user verification. It is intentionally conservative: CI success is not counted as third-party adoption.
+
+**Observation date:** 2026-08-18
+
+| Path | Repository / CI evidence | Maintainer-side evidence | Independent user verification | Current limitation |
+|---|---|---|---|---|
+| Isolated no-key startup | `scripts/release-provider-smoke.py --provider openai --no-key-only` is part of the documented readiness path and normal repository checks | The project documents the expected PASS contract: startup, `v0.2.0` health, unconfigured-provider behavior, and secret redaction | None verified yet | Does not prove a real provider connection or model response |
+| Windows source bootstrap | Platform Readiness exercises `scripts/setup-windows.ps1` on `windows-latest` | Guarded bootstrap and `-CheckOnly` behavior are documented in README and `docs/try-without-api.md` | None verified yet; Issue #15 requests a fresh external Windows test | CI cannot reproduce every local Windows configuration |
+| Docker Compose local start | Platform Readiness builds, starts, health-checks, and exercises the localhost-only Compose path | The repository documents `docker compose up --build -d` as the lowest-friction no-key path | None verified yet; Issue #56 requests macOS/Linux verification | CI coverage is not equivalent to independent macOS/Linux/Windows use |
+| Provider-backed first chat and restart persistence | Release/provider smoke infrastructure exists for release candidates | Issue #7 defines the real provider → first chat → restart-persistence validation path | None verified yet | Requires a tester-owned supported provider credential or explicitly enabled local provider |
+| Mobile/PWA readiness | Platform Readiness includes mobile/PWA checks | Deployment and secure-context constraints are documented | None verified yet | Automated readiness does not replace physical-device verification |
+
+## Evidence rules
+
+- A green CI run proves only the checks represented by that workflow.
+- Maintainer dogfooding is first-party product evidence, not independent adoption.
+- Stars and forks are reach signals, not proof that the software was installed or used successfully.
+- An independent verification entry requires a public issue, pull request, or comment that identifies the tested path and environment without exposing private data.
+- Negative or failed tests remain valid evidence and should not be removed merely because they are unfavorable.
+
+## How to close the gaps
+
+- Windows fresh install: use Issue #15.
+- macOS/Linux Docker path: use Issue #56.
+- First run / provider / persistence: use Issue #7.
+- Ongoing real-world workflow: use Issue #55 or the `Real-world use` issue form.
+
+See `docs/evidence-ledger.md` for the dated project evidence snapshot and `docs/real-world-use.md` for the evidence boundary.


### PR DESCRIPTION
Closes #67.
Closes #68.
Closes #69.

## Summary

- links the existing no-key verification path directly from README;
- adds `docs/support-matrix.md` to separate CI, maintainer-side evidence, and independent verification;
- adds `docs/maintainer-evidence-summary.md` for a concise factual maintainer/project snapshot;
- keeps external adoption explicitly unverified until a public third-party issue, PR, or use report exists.

## Evidence boundary

This change does not convert CI, maintainer dogfooding, stars, forks, or generated feedback into independent adoption evidence.