### PR TITLE
feat: add bounded project handoff snapshots

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ The stable release was published only after the documented real-inference, resta
    - External issue/PR feedback instead of synthetic adoption signals.
 2. **Strengthen Project Continuity**
    - Make Tasks, Conversations, Files, Outcomes, decisions, changed files, blockers, and reviewed Project Memory first-class project state.
-   - Add compact and full handoff forms plus crash/restart recovery without copying private provider sessions.
+   - Compact/full read-only handoff snapshots are now implemented at the API layer with bounded payloads and no provider-session copying; dedicated UI handoff forms and explicit crash/restart recovery remain to be completed.
 3. **Finish the Settings center**
    - Unify AI services, default models, voice, memory/privacy, appearance, data controls, MCP, and diagnostics.
    - Keep credential values server-side and never return them to the browser.

--- a/apps/api/src/personal_ai_os/main.py
+++ b/apps/api/src/personal_ai_os/main.py
@@ -13,6 +13,7 @@ from . import __version__
 from .auth import AccessProtectionMiddleware, create_auth_router
 from .config import Settings
 from .p5_routes import router as p5_router
+from .project_handoff_routes import router as project_handoff_router
 from .project_state_routes import router as project_state_router
 from .project_workflow_routes import router as project_workflow_router
 from .routes import router
@@ -59,6 +60,7 @@ def create_app(settings: Settings | None = None, runtime: Runtime | None = None)
     app.include_router(router)
     app.include_router(project_state_router)
     app.include_router(project_workflow_router)
+    app.include_router(project_handoff_router)
     app.include_router(p5_router)
     app.include_router(create_auth_router(app_runtime.settings))
     web_dir = os.getenv("PERSONAL_AI_OS_WEB_DIR")

--- a/apps/api/src/personal_ai_os/project_handoff.py
+++ b/apps/api/src/personal_ai_os/project_handoff.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from .db import Database
+from .project_state import ProjectStateService
+from .project_workflow import ProjectWorkflowService
+
+
+HandoffMode = Literal["compact", "full"]
+
+MAX_COMPACT_STATES = 20
+MAX_COMPACT_EXPERIENCES = 20
+MAX_COMPACT_WORKFLOWS = 10
+MAX_FULL_STATES = 200
+MAX_FULL_EXPERIENCES = 200
+MAX_FULL_WORKFLOWS = 100
+
+
+class ProjectHandoffService:
+    """Build bounded, read-only project handoff snapshots from private continuity state.
+
+    Handoffs reuse the existing project-scoped state/workflow stores. They do not copy provider
+    sessions, state history, workflow transition evidence, credentials, or generic Memory records.
+    """
+
+    def __init__(
+        self,
+        audit_database: Database,
+        *,
+        data_dir: Path | None = None,
+        tenant_id: str | None = None,
+    ) -> None:
+        self.state = ProjectStateService(
+            audit_database,
+            data_dir=data_dir,
+            tenant_id=tenant_id,
+        )
+        self.workflow = ProjectWorkflowService(
+            audit_database,
+            data_dir=data_dir,
+            tenant_id=tenant_id,
+        )
+
+    @staticmethod
+    def _compact_state(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "namespace": item["namespace"],
+            "key": item["key"],
+            "value": item["value"],
+            "version": item["version"],
+            "status": item["status"],
+            "updated_at": item["updated_at"],
+        }
+
+    @staticmethod
+    def _compact_experience(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "namespace": item["namespace"],
+            "text": item["text"],
+            "confidence": item["confidence"],
+            "created_at": item["created_at"],
+        }
+
+    @staticmethod
+    def _compact_workflow(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "workflow_id": item["workflow_id"],
+            "run_key": item["run_key"],
+            "completed_steps": item["completed_steps"],
+            "current_step": item["current_step"],
+            "next_step": item["next_step"],
+            "version": item["version"],
+            "status": item["status"],
+            "updated_at": item["updated_at"],
+        }
+
+    def build(self, project_id: str, *, mode: HandoffMode = "compact") -> dict[str, Any]:
+        states = self.state.list_state(project_id)
+        experiences = self.state.list_experience(project_id)
+        workflows = self.workflow.list_workflows(project_id)
+
+        if mode == "compact":
+            state_limit = MAX_COMPACT_STATES
+            experience_limit = MAX_COMPACT_EXPERIENCES
+            workflow_limit = MAX_COMPACT_WORKFLOWS
+            selected_states = [
+                self._compact_state(item) for item in states[:state_limit]
+            ]
+            selected_experiences = [
+                self._compact_experience(item)
+                for item in experiences[:experience_limit]
+            ]
+            selected_workflows = [
+                self._compact_workflow(item)
+                for item in workflows[:workflow_limit]
+            ]
+        elif mode == "full":
+            state_limit = MAX_FULL_STATES
+            experience_limit = MAX_FULL_EXPERIENCES
+            workflow_limit = MAX_FULL_WORKFLOWS
+            selected_states = states[:state_limit]
+            selected_experiences = experiences[:experience_limit]
+            selected_workflows = workflows[:workflow_limit]
+        else:
+            raise ValueError(f"Unsupported handoff mode: {mode}")
+
+        truncated = (
+            len(states) > state_limit
+            or len(experiences) > experience_limit
+            or len(workflows) > workflow_limit
+        )
+        return {
+            "project_id": project_id,
+            "mode": mode,
+            "counts": {
+                "states": len(states),
+                "experiences": len(experiences),
+                "workflows": len(workflows),
+            },
+            "truncated": truncated,
+            "states": selected_states,
+            "experiences": selected_experiences,
+            "workflows": selected_workflows,
+        }

--- a/apps/api/src/personal_ai_os/project_handoff_routes.py
+++ b/apps/api/src/personal_ai_os/project_handoff_routes.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from .project_handoff import ProjectHandoffService
+
+
+router = APIRouter(prefix="/api/projects/{project_id}/handoff", tags=["project-handoff"])
+
+
+def _service(project_id: str, request: Request) -> ProjectHandoffService:
+    runtime = request.app.state.runtime
+    try:
+        runtime.projects.get(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return ProjectHandoffService(
+        runtime.database,
+        data_dir=runtime.settings.data_dir,
+        tenant_id=runtime.settings.tenant_id,
+    )
+
+
+@router.get("")
+def get_project_handoff(
+    project_id: str,
+    request: Request,
+    mode: Literal["compact", "full"] = Query(default="compact"),
+) -> dict[str, object]:
+    return _service(project_id, request).build(project_id, mode=mode)

--- a/apps/api/tests/test_project_handoff.py
+++ b/apps/api/tests/test_project_handoff.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _seed_handoff(client: TestClient, project_id: str = "general") -> None:
+    saved = client.put(
+        f"/api/projects/{project_id}/state/records",
+        json={
+            "namespace": "decision",
+            "key": "current",
+            "value": {"status": "reviewed"},
+            "source": "test-state",
+            "confidence": 0.95,
+            "expected_version": 0,
+        },
+    )
+    assert saved.status_code == 200
+
+    experience = client.post(
+        f"/api/projects/{project_id}/state/experience",
+        json={
+            "namespace": "review",
+            "text": "Keep verified state ahead of reconstruction.",
+            "source": "test-review",
+            "confidence": 0.9,
+        },
+    )
+    assert experience.status_code == 201
+
+    workflow = client.post(
+        f"/api/projects/{project_id}/workflows",
+        json={
+            "workflow_id": "handoff-check",
+            "run_key": "synthetic-run",
+            "steps": ["review", "continue"],
+            "source": "test-workflow",
+        },
+    )
+    assert workflow.status_code == 201
+
+    advanced = client.post(
+        f"/api/projects/{project_id}/workflows/handoff-check/synthetic-run/advance",
+        json={
+            "next_step": "review",
+            "expected_version": 1,
+            "evidence": {"private_receipt": "must-not-appear-in-handoff"},
+            "source": "test-workflow",
+        },
+    )
+    assert advanced.status_code == 200
+
+
+def test_compact_handoff_is_bounded_current_state_without_receipts(client: TestClient) -> None:
+    _seed_handoff(client)
+
+    response = client.get("/api/projects/general/handoff")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["project_id"] == "general"
+    assert payload["mode"] == "compact"
+    assert payload["truncated"] is False
+    assert payload["counts"] == {"states": 1, "experiences": 1, "workflows": 1}
+
+    state = payload["states"][0]
+    assert state["value"] == {"status": "reviewed"}
+    assert "source" not in state
+    assert "confidence" not in state
+
+    experience = payload["experiences"][0]
+    assert experience["text"] == "Keep verified state ahead of reconstruction."
+    assert "source" not in experience
+
+    workflow = payload["workflows"][0]
+    assert workflow["completed_steps"] == ["review"]
+    assert workflow["next_step"] == "continue"
+    assert "steps" not in workflow
+    assert "source" not in workflow
+
+    serialized = response.text
+    assert "private_receipt" not in serialized
+    assert "must-not-appear-in-handoff" not in serialized
+
+
+def test_full_handoff_keeps_rich_current_records_but_not_transition_evidence(client: TestClient) -> None:
+    _seed_handoff(client)
+
+    response = client.get("/api/projects/general/handoff?mode=full")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["mode"] == "full"
+    assert payload["states"][0]["source"] == "test-state"
+    assert payload["states"][0]["confidence"] == 0.95
+    assert payload["experiences"][0]["source"] == "test-review"
+    assert payload["workflows"][0]["steps"] == ["review", "continue"]
+    assert payload["workflows"][0]["source"] == "test-workflow"
+
+    serialized = response.text
+    assert "private_receipt" not in serialized
+    assert "must-not-appear-in-handoff" not in serialized
+
+
+def test_handoff_is_project_scoped(client: TestClient) -> None:
+    _seed_handoff(client, project_id="general")
+
+    other = client.get("/api/projects/p5/handoff")
+    assert other.status_code == 200
+    assert other.json()["counts"] == {"states": 0, "experiences": 0, "workflows": 0}
+    assert other.json()["states"] == []
+    assert other.json()["experiences"] == []
+    assert other.json()["workflows"] == []
+
+
+def test_handoff_rejects_unknown_project_and_invalid_mode(client: TestClient) -> None:
+    unknown = client.get("/api/projects/not-a-project/handoff")
+    assert unknown.status_code == 404
+
+    invalid = client.get("/api/projects/general/handoff?mode=unbounded")
+    assert invalid.status_code == 422

--- a/docs/project-handoff.md
+++ b/docs/project-handoff.md
@@ -1,0 +1,60 @@
+# Project handoff snapshots
+
+Personal AI OS exposes a read-only handoff surface for continuing a project in a new conversation or client without treating chat-window history as the source of truth.
+
+## API
+
+```text
+GET /api/projects/{project_id}/handoff
+GET /api/projects/{project_id}/handoff?mode=compact
+GET /api/projects/{project_id}/handoff?mode=full
+```
+
+`compact` is the default. Both modes are bounded.
+
+## Compact handoff
+
+The compact form is intended for routine continuation. It includes current project-scoped state, recent project experience, and recent workflow positions, but strips fields that are not needed to resume the work.
+
+Limits:
+
+- 20 current state records
+- 20 recent experience records
+- 10 recent workflow runs
+
+Compact state records keep namespace, key, value, version, status, and update time. Compact workflow records keep the current/next/completed step position and version/status. Sources and workflow step definitions are omitted from the compact form.
+
+## Full handoff
+
+The full form keeps the richer current records already available through the private state/workflow APIs, but remains bounded:
+
+- 200 current state records
+- 200 recent experience records
+- 100 recent workflow runs
+
+The response includes total record counts and `truncated=true` when any limit is exceeded.
+
+`full` means richer current-state detail; it does **not** mean an unbounded export.
+
+## Deliberate exclusions
+
+Neither handoff mode includes:
+
+- project state history;
+- workflow transition receipts or transition evidence;
+- provider credentials, tokens, cookies, or sessions;
+- raw provider conversations outside the normal conversation API;
+- generic Memory records from another surface;
+- another project's private state.
+
+A handoff is assembled from the same physically isolated per-project SQLite store already used by persistent project state and workflow gates. It does not create a second copy of project state and does not write a new audit payload containing the private values.
+
+## Security and privacy boundary
+
+The route is served by the same application and access middleware as the existing private project-state APIs. Unknown project IDs fail closed with HTTP 404, and unsupported handoff modes fail validation.
+
+The handoff feature does not automate third-party account switching or authentication. It only packages Personal AI OS project continuity data that the caller is already authorized to read.
+
+## Remaining roadmap work
+
+This API provides the data contract for compact/full handoff snapshots. A dedicated UI handoff form, explicit crash/restart recovery workflow, and any external-client adapter remain separate work and must preserve the same project-isolation and privacy boundaries.


### PR DESCRIPTION
## Summary

Add a read-only project handoff API for continuing long-running work from the existing private project state/workflow stores.

- `GET /api/projects/{project_id}/handoff` defaults to a compact snapshot;
- `?mode=full` returns richer current records while remaining bounded;
- compact mode strips non-essential `source`/workflow-definition fields;
- both modes include total counts and an explicit `truncated` flag;
- neither mode exposes state history, workflow transition receipts/evidence, provider credentials/sessions, generic Memory, or another project's private state;
- add API tests for compact/full behavior, transition-evidence exclusion, project isolation, unknown projects, and invalid modes;
- document the privacy boundary and update the roadmap only for the API snapshot milestone.

## Limits

Compact: 20 states / 20 experiences / 10 workflows.
Full: 200 states / 200 experiences / 100 workflows.

`full` is richer current state, not an unbounded export.

## Security / architecture

No database schema change, authentication change, provider change, or project-domain logic change. The route uses the existing application access middleware and physically isolated per-project SQLite stores.

## Remaining scope

Dedicated UI handoff forms, explicit crash/restart recovery, and external-client adapters remain separate roadmap work.