### PR TITLE
docs: align public support and maintainer claims

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-Personal AI OS is currently maintained by a small maintainer group.
+Personal AI OS is currently maintainer-led with one primary maintainer and public contribution paths for future maintainers.
 
 ## Primary maintainer
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,8 +5,10 @@ Personal AI OS is an early open-source project. Support is provided through publ
 ## Where to ask
 
 - Reproducible software problem: open a Bug report.
-- Fresh-install or first-run feedback: use Issue #7.
-- Newcomer Windows no-key validation: see Issue #15.
+- Provider-backed first chat and restart-persistence feedback: use Issue #7.
+- Windows fresh-install / no-key validation: use Issue #15.
+- macOS/Linux Docker fresh-install validation: use Issue #56.
+- Genuine real-world workflow use or attempted use: use Issue #55.
 - Feature proposal: use the Feature request form.
 - Security or credential exposure: follow `SECURITY.md` and do not post sensitive details in a public issue.
 


### PR DESCRIPTION
## Summary

Remove two public-documentation inconsistencies after the handoff and validation-entrypoint work:

- align `SUPPORT.md` with the four genuine validation paths already exposed from the README (#7, #15, #55, #56);
- replace the ambiguous claim that the repository is maintained by a "small maintainer group" with the verifiable current state: one primary maintainer plus public contribution paths for future maintainers.

## Why

These are claim-accuracy and contributor-routing fixes. They do not create or imply user adoption, additional maintainers, or OpenAI approval.

## Scope

Documentation only: `SUPPORT.md` and `MAINTAINERS.md`.