### PR TITLE
feat: add explicit project continuity preview

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ The stable release was published only after the documented real-inference, resta
    - External issue/PR feedback instead of synthetic adoption signals.
 2. **Strengthen Project Continuity**
    - Make Tasks, Conversations, Files, Outcomes, decisions, changed files, blockers, and reviewed Project Memory first-class project state.
-   - Compact/full read-only handoff snapshots are now implemented at the API layer with bounded payloads and no provider-session copying; dedicated UI handoff forms and explicit crash/restart recovery remain to be completed.
+   - Compact/full read-only handoff snapshots and an explicit Projects-screen preview are implemented with bounded payloads and no provider-session copying; automatic crash detection and guided restart recovery remain to be completed.
 3. **Finish the Settings center**
    - Unify AI services, default models, voice, memory/privacy, appearance, data controls, MCP, and diagnostics.
    - Keep credential values server-side and never return them to the browser.

--- a/apps/web/components/project-handoff-panel.tsx
+++ b/apps/web/components/project-handoff-panel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ClipboardCopy, RefreshCw, ShieldCheck, X } from "lucide-react";
+import { apiJson } from "@/lib/api";
+
+type HandoffMode = "compact" | "full";
+type HandoffSnapshot = {
+  project_id: string;
+  mode: HandoffMode;
+  counts: { states: number; experiences: number; workflows: number };
+  truncated: boolean;
+  states: unknown[];
+  experiences: unknown[];
+  workflows: unknown[];
+};
+
+type Props = {
+  projectId: string;
+  projectName: string;
+};
+
+export function ProjectHandoffPanel({ projectId, projectName }: Props) {
+  const [snapshot, setSnapshot] = useState<HandoffSnapshot | null>(null);
+  const [loadingMode, setLoadingMode] = useState<HandoffMode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function load(mode: HandoffMode) {
+    setLoadingMode(mode);
+    setError(null);
+    setCopied(false);
+    try {
+      const data = await apiJson<HandoffSnapshot>(
+        `/api/projects/${encodeURIComponent(projectId)}/handoff?mode=${mode}`,
+      );
+      setSnapshot(data);
+    } catch {
+      setError("Continuity snapshot could not be loaded. Confirm the API is running, then try again.");
+    } finally {
+      setLoadingMode(null);
+    }
+  }
+
+  async function copySnapshot() {
+    if (!snapshot) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(snapshot, null, 2));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setError("The snapshot is visible below, but this browser did not allow clipboard access.");
+    }
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="mt-4 border-t border-line pt-4">
+        <button
+          type="button"
+          className="button-quiet px-2 text-accent-hover"
+          disabled={loadingMode !== null}
+          onClick={() => void load("compact")}
+        >
+          <ShieldCheck aria-hidden size={15} />
+          {loadingMode === "compact" ? "Loading continuity…" : "Continuity"}
+        </button>
+        {error ? <p className="mt-2 text-xs leading-5 text-danger">{error}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <section className="mt-4 rounded-card border border-line bg-surface/70 p-4" aria-label={`${projectName} continuity handoff`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="eyebrow">Continuity snapshot</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h4 className="font-medium text-text-primary">{projectName}</h4>
+            <span className="chip capitalize">{snapshot.mode}</span>
+            {snapshot.truncated ? <span className="chip">Bounded</span> : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="button-quiet px-2"
+          aria-label="Close continuity preview"
+          onClick={() => {
+            setSnapshot(null);
+            setError(null);
+            setCopied(false);
+          }}
+        >
+          <X aria-hidden size={15} />
+        </button>
+      </div>
+
+      <p className="mt-3 text-xs leading-5 text-text-secondary">
+        {snapshot.counts.states} state · {snapshot.counts.experiences} experience · {snapshot.counts.workflows} workflow
+        {snapshot.counts.workflows === 1 ? "" : "s"}. This preview is read-only and comes from persisted project continuity state.
+      </p>
+      {snapshot.truncated ? (
+        <p className="mt-2 text-xs leading-5 text-warning">
+          Older records are outside this bounded snapshot. Total counts above still reflect the stored project state.
+        </p>
+      ) : null}
+      {snapshot.mode === "compact" ? (
+        <p className="mt-2 text-xs leading-5 text-text-tertiary">
+          Compact omits source metadata and workflow definitions. Full details remain bounded and require an explicit choice.
+        </p>
+      ) : (
+        <p className="mt-2 text-xs leading-5 text-text-tertiary">
+          Full includes richer current-record metadata, but still excludes state history, transition receipts, provider sessions, and credentials.
+        </p>
+      )}
+
+      <pre className="mt-3 max-h-64 overflow-auto rounded-control border border-line bg-canvas p-3 text-[11px] leading-5 text-text-secondary">
+        {JSON.stringify(snapshot, null, 2)}
+      </pre>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="button-quiet px-3"
+          disabled={loadingMode !== null}
+          onClick={() => void load("compact")}
+        >
+          <RefreshCw aria-hidden size={14} />
+          {loadingMode === "compact" ? "Refreshing…" : "Refresh compact"}
+        </button>
+        {snapshot.mode === "compact" ? (
+          <button
+            type="button"
+            className="button-quiet px-3"
+            disabled={loadingMode !== null}
+            onClick={() => void load("full")}
+          >
+            <ShieldCheck aria-hidden size={14} />
+            {loadingMode === "full" ? "Loading full…" : "Load full details"}
+          </button>
+        ) : null}
+        <button type="button" className="button-quiet px-3" onClick={() => void copySnapshot()}>
+          {copied ? <Check aria-hidden size={14} /> : <ClipboardCopy aria-hidden size={14} />}
+          {copied ? "Copied" : "Copy snapshot"}
+        </button>
+      </div>
+      {error ? <p className="mt-2 text-xs leading-5 text-danger">{error}</p> : null}
+    </section>
+  );
+}

--- a/apps/web/components/project-handoff-panel.tsx
+++ b/apps/web/components/project-handoff-panel.tsx
@@ -114,7 +114,7 @@ export function ProjectHandoffPanel({ projectId, projectName }: Props) {
         </p>
       )}
 
-      <pre className="mt-3 max-h-64 overflow-auto rounded-control border border-line bg-canvas p-3 text-[11px] leading-5 text-text-secondary">
+      <pre className="mt-3 max-h-64 overflow-auto rounded-control border border-line bg-surface-subtle p-3 text-[11px] leading-5 text-text-secondary">
         {JSON.stringify(snapshot, null, 2)}
       </pre>
 

--- a/apps/web/components/projects-grid.tsx
+++ b/apps/web/components/projects-grid.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState, type ComponentType } from "react";
 import { ArrowRight, CircleDot, Code2, Dices, FolderKanban, Microscope, Sparkles } from "lucide-react";
 import { apiJson } from "@/lib/api";
+import { ProjectHandoffPanel } from "@/components/project-handoff-panel";
 import { EmptyState, ErrorState, LoadingState } from "@/components/ui-states";
 
 type Project = { id: string; name: string; description: string; icon: string; status: string };
@@ -84,6 +85,7 @@ export function ProjectsGrid() {
                   <span className="min-w-0 text-xs text-text-tertiary"><span className="block">Last activity</span><span className="mt-0.5 block truncate text-text-secondary" title={activity?.summary}>{activity ? timeAgo(activity.created_at) : "No activity yet"}</span></span>
                   <Link href={item.id === "p5" ? "/projects/p5" : `/chat?project=${encodeURIComponent(item.id)}`} className="button-quiet px-2 text-accent-hover">Open <ArrowRight aria-hidden size={15} /></Link>
                 </div>
+                <ProjectHandoffPanel projectId={item.id} projectName={item.name} />
               </article>
             );
           })}

--- a/docs/project-handoff.md
+++ b/docs/project-handoff.md
@@ -36,6 +36,18 @@ The response includes total record counts and `truncated=true` when any limit is
 
 `full` means richer current-state detail; it does **not** mean an unbounded export.
 
+## Projects UI
+
+The Projects screen exposes continuity on each active project card. It does not fetch a handoff snapshot during ordinary page load.
+
+- `Continuity` is an explicit user action and loads the compact snapshot first.
+- The snapshot is previewed before any clipboard copy action.
+- Full details require a second explicit action and keep the same server-side bounds.
+- The UI surfaces total counts and whether the response was truncated.
+- Closing the preview discards the client-side snapshot; the UI does not persist a second handoff copy.
+
+This makes persisted project state and workflow position inspectable again after an application restart without reconstructing missing facts from chat history.
+
 ## Deliberate exclusions
 
 Neither handoff mode includes:
@@ -57,4 +69,4 @@ The handoff feature does not automate third-party account switching or authentic
 
 ## Remaining roadmap work
 
-This API provides the data contract for compact/full handoff snapshots. A dedicated UI handoff form, explicit crash/restart recovery workflow, and any external-client adapter remain separate work and must preserve the same project-isolation and privacy boundaries.
+The API and explicit Projects-screen preview cover bounded handoff inspection and manual recovery visibility. Automatic crash detection, a guided restart-recovery workflow, and any external-client adapter remain separate work and must preserve the same project-isolation and privacy boundaries.


### PR DESCRIPTION
## Summary

Expose the bounded handoff contract from the Projects UI without automatically reading private continuity state.

- each active project gets an explicit `Continuity` action;
- the first request is always the bounded compact handoff;
- full details require a second explicit user action;
- snapshots are previewed before clipboard copy;
- total counts and truncation are surfaced;
- closing the preview discards the client-side snapshot;
- no new client persistence, provider-session copying, database schema, or authentication surface is added.

## Recovery boundary

After an application restart, the user can explicitly inspect persisted project state and workflow position from Projects without reconstructing missing facts from chat history. This PR does **not** claim automatic crash detection or guided restart recovery; those remain separate work.

## Documentation

Update `docs/project-handoff.md` and `ROADMAP.md` to reflect the exact implemented boundary.