### PR TITLE
fix: update vulnerable nanoid resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1427,11 +1427,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2921,8 +2916,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   neo-async@2.6.2: {}
@@ -3022,7 +3015,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
- replaces the vulnerable transitive `nanoid@3.3.17` resolution with patched `nanoid@3.3.18`
- changes only `pnpm-lock.yaml`; no product behavior, provider, plugin, or UI scope is added
- remediates Dependabot alert #3 (`GHSA-2v37-7h3g-55p8` / `CVE-2026-67213`)

## Verification
- `pnpm install --frozen-lockfile` (lockfile policy passed; no new lock resolution)
- `pnpm check:web`
- `pnpm build` (completed; Wrangler emitted a non-fatal user-log permission warning)
- API test batches: 134 passed, 2 skipped
- Python compile/version checks and `release-provider-smoke.py --provider openai --no-key-only`

## Release boundary
This PR is required before v0.3.0 release evidence is collected. The prior PR-level provider smoke remains skipped and is not used as release evidence.