### PR TITLE
docs: record verified v0.3.0 release evidence

### DIFF
--- a/docs/application-readiness-audit.md
+++ b/docs/application-readiness-audit.md
@@ -1,34 +1,36 @@
 # Application readiness audit
 
-**Observed:** 2026-08-30. **Authority order:** live GitHub repository facts, then this local worktree. This audit does not treat a local commit, generated file, or workflow definition as proof that a remote check or GitHub Release exists.
+**Observed:** 2026-08-31. **Authority order:** live GitHub repository facts, then this local worktree. This audit does not treat a local commit, generated file, or workflow definition as proof that a remote check or GitHub Release exists.
 
 | Item | Status | Fresh finding |
 | --- | --- | --- |
-| `main` | VERIFIED | Protected remote `main` is `3f974bf514c874f3f3d26efd8f1d64388ce0d837`. |
-| `release/v0.3.0` | VERIFIED | Remote candidate is `493717f091c8e0c427e473c35c1db01dc7392d2f`, eight commits ahead of `main`. |
+| `main` | VERIFIED | Remote `main` is `e5275ef24d5154974c324121db41bb870bac049c` after the v0.3.0 release PR merge. |
+| `release/v0.3.0` | VERIFIED | Remote release branch head is `8e14e857ffbae642268ea069c9b9d1f0c72f5cdd`, the exact verified v0.3.0 candidate. |
+| `v0.3.0` tag / GitHub Release | VERIFIED | Annotated `v0.3.0` resolves to `8e14e857ffbae642268ea069c9b9d1f0c72f5cdd`; [GitHub Release v0.3.0](https://github.com/sui-ni2/personal-ai-os/releases/tag/v0.3.0) published 2026-08-31. |
 | `v0.2.0` tag | VERIFIED | Lightweight tag points to `934efa959d2487c6942951d90bb543b4104369f6`. |
 | `v0.2.0` GitHub Release / notes / assets | MISSING | Live GitHub Releases query returned zero releases. No public Release, Release notes, or Release assets may be claimed. |
 | README / release docs before this audit | CONTRADICTED | Several public documents said a `v0.2.0` GitHub Release remained available, contrary to the live Release query. |
 | `CHANGELOG.md` | PARTIAL | Contains a useful tagged-release entry, but its old sentence claiming a published GitHub Release required correction. |
 | `SECURITY.md`, `CONTRIBUTING.md`, `AGENTS.md` | VERIFIED | Present and aligned with local-first, no-secret, project-contract boundaries. |
+| Dependabot alert #3 | VERIFIED | PR #89 updated transitive `nanoid` to 3.3.18; GitHub records `GHSA-2v37-7h3g-55p8` as fixed and the current open-high query is empty. |
 | Evidence ledger and maintainer summary before this audit | CONTRADICTED | Both repeated the nonexistent v0.2.0 GitHub Release claim and listed four rather than five open issues. |
 | Issue #7 / #15 / #55 / #56 | VERIFIED | Open external-validation entry points. No completed independent result was found. |
-| Issue #85 | PARTIAL | Open; bounded handoff UI existed, but crash/restart recovery did not. This worktree adds the missing recovery path pending CI/review. |
+| Issue #85 | VERIFIED | Closed after PR #88 merged and its exact main SHA passed CI, CodeQL, and Platform Readiness. |
 | Open pull requests | VERIFIED | Zero at observation time. |
 | Reach | VERIFIED | 59 stars, 14 forks, 2 subscribers/watchers at observation time. These are not adoption evidence. |
 | External contributor / tester evidence | MISSING | No qualifying non-maintainer install result, real workflow result, focused external PR, or external re-test was identified. |
 | Independent adoption | MISSING | `INDEPENDENT_ADOPTION_VERIFIED = 0`. |
-| CI on v0.3.0 base SHA | PARTIAL | CI backend and frontend jobs succeeded in run `33155548426` for `493717f…`. |
-| CodeQL on v0.3.0 base SHA | MISSING | No check run attached to the exact v0.3.0 SHA. |
-| Dependency Review on v0.3.0 base SHA | MISSING | No check run attached to the exact v0.3.0 SHA. |
-| Platform Readiness on v0.3.0 base SHA | MISSING | No check run attached to the exact v0.3.0 SHA. |
-| Release provider smoke on v0.3.0 base SHA | MISSING | No successful exact-SHA run was found. |
-| Release evidence verifier | BLOCKED_EXTERNAL | The exact-SHA bundle lacks four required fresh remote gates, so the verifier must remain blocked. |
-| Docker / Windows / mobile / privacy | PARTIAL | Source-controlled checks and documented paths exist; the v0.3.0 candidate still needs exact-SHA Platform Readiness evidence. |
-| Current worktree checks | PARTIAL | Full local API tests (with two existing skips), Python compilation, version consistency, and no-key provider smoke passed. Frontend dependencies could not complete installation because registry tarball requests timed out; this remains local evidence only. |
+| CI on v0.3.0 candidate SHA | VERIFIED | Success in [run 33351296808](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296808) for `8e14e85…`. |
+| CodeQL on v0.3.0 candidate SHA | VERIFIED | Success in [run 33351296814](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296814) for `8e14e85…`. |
+| Dependency Review on v0.3.0 candidate SHA | VERIFIED | Success in [run 33351296818](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296818) for `8e14e85…`. |
+| Platform Readiness on v0.3.0 candidate SHA | VERIFIED | Success in [run 33351296833](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296833) for `8e14e85…`. |
+| Release provider smoke on v0.3.0 candidate SHA | VERIFIED | Success in [run 33351296811](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296811) for `8e14e85…`. |
+| Release evidence verifier | VERIFIED | `ready_to_tag` with no blockers using the exact five-gate bundle and GitHub server time. |
+| Docker / Windows / mobile / privacy | VERIFIED | Exact-SHA Platform Readiness succeeded before the normal release-PR merge. |
+| Current worktree checks | VERIFIED | Full local API tests (with two existing skips), Python compilation, version consistency, frozen lockfile validation, frontend typecheck/build, and no-key provider smoke passed. Wrangler emitted a non-fatal user-log permission warning during the local build. |
 
 ## Consequence
 
-The release decision is **RELEASE_BLOCKED**. A tag or GitHub Release must not be created or implied until a frozen new release-candidate SHA has one fresh successful result for every verifier-required gate: CI, CodeQL, Dependency Review, Platform Readiness, and Release provider smoke.
+The v0.3.0 decision is **RELEASED**. Its annotated tag, GitHub Release, exact-SHA evidence bundle, normal release-PR merge, and no-open-high-alert snapshot are all independently recorded above.
 
 The application evidence is useful for maintainer activity and product direction, but independent adoption remains an external-evidence gap that code cannot manufacture.

--- a/docs/codex-for-oss-application.md
+++ b/docs/codex-for-oss-application.md
@@ -1,6 +1,6 @@
 # Codex for Open Source application evidence
 
-**Observed 2026-08-30:** Personal AI OS is Apache-2.0 and publicly maintained. GitHub showed 59 stars, 14 forks, five open validation issues, and no open pull requests. `v0.2.0` is a tag, not a published GitHub Release. `release/v0.3.0` remains blocked pending fresh exact-SHA release gates. `INDEPENDENT_ADOPTION_VERIFIED = 0`.
+**Observed 2026-08-31:** Personal AI OS is Apache-2.0 and publicly maintained. GitHub showed 59 stars, 14 forks, four open validation issues, and no open pull requests. `v0.3.0` is an annotated tag with a published GitHub Release after five exact-SHA gates. `INDEPENDENT_ADOPTION_VERIFIED = 0`.
 
 ## Maintainer role
 
@@ -10,7 +10,7 @@ The primary maintainer performs architecture and boundary design, focused PR rev
 
 ### Reach
 
-59 stars and 14 forks are public reach signals as observed on 2026-08-30. They are not counted as adoption.
+59 stars and 14 forks are public reach signals as observed on 2026-08-31. They are not counted as adoption.
 
 ### Active maintenance
 
@@ -24,7 +24,7 @@ Providers are replaceable execution engines, while long-running work is commonly
 
 ### WHY_REPOSITORY_QUALIFIES
 
-Personal AI OS is an Apache-2.0, local-first, provider-neutral workspace for durable AI project state. As observed on 2026-08-30 it has 59 stars and 14 forks, plus active public CI, security, release-readiness, and privacy maintenance. It keeps Projects, reviewed Memory, tasks, decisions, outcomes, and work history user-controlled while providers remain replaceable. Independent adoption is not claimed.
+Personal AI OS is an Apache-2.0, local-first, provider-neutral workspace for durable AI project state. As observed on 2026-08-31 it has 59 stars, 14 forks, a published v0.3.0 Release, and active public CI, security, and privacy maintenance. It keeps Projects, reviewed Memory, tasks, decisions, outcomes, and work history user-controlled while providers remain replaceable. Independent adoption is not claimed.
 
 ### HOW_API_CREDITS_WILL_BE_USED
 

--- a/docs/evidence-ledger.md
+++ b/docs/evidence-ledger.md
@@ -2,24 +2,25 @@
 
 This page records public evidence about Personal AI OS without treating repository activity as proof of independent adoption. Mutable metrics are dated, and external-use claims require a public source that can be inspected independently.
 
-## Snapshot — 2026-08-30
+## Snapshot — 2026-08-31
 
 ## Reach
 
-- Public repository snapshot observed on 2026-08-30: **59 stars, 14 forks, and 2 subscribers/watchers**.
+- Public repository snapshot observed on 2026-08-31: **59 stars, 14 forks, and 2 subscribers/watchers**.
 - These are public reach signals only. They are not independent-adoption evidence.
 
 ## Maintenance
 
 - Public Apache-2.0 repository: `sui-ni2/personal-ai-os`.
 - First stable tagged release: `v0.2.0` at `934efa959d2487c6942951d90bb543b4104369f6`. A live GitHub Releases query returned **zero releases** on 2026-08-30, so this repository does not claim a published v0.2.0 GitHub Release, release notes, or release assets.
+- Stable `v0.3.0` is an annotated tag resolving to `8e14e857ffbae642268ea069c9b9d1f0c72f5cdd` and has a published [GitHub Release](https://github.com/sui-ni2/personal-ai-os/releases/tag/v0.3.0). PR #90 merged its release preparation to `main` as `e5275ef24d5154974c324121db41bb870bac049c` after five exact-SHA gates and a `ready_to_tag` verifier result.
 - Runnable local-first application with Chat, Projects, reviewed Memory, execution history, MCP tooling, OpenAI/Anthropic adapters, and optional local Ollama support; the runnable surface is documented in `README.md`.
 - Repository CI covers backend tests, frontend checks/builds, platform readiness, CodeQL, and dependency review; repository-admin hardening is tracked in Issue #39.
 - Executable maintainer helpers cover CI failure classification, dependency-update risk summaries, release-evidence verification, and external tester-feedback triage. Their fail-closed contracts and focused tests are documented in `docs/maintainer-automation.md`.
 - PR #74 remains a concrete dependency-maintenance example: Platform Readiness prevented two incomplete Dependabot upgrades from merging, the peer dependencies were aligned together, and the replacement passed the repository's required verification before merge.
 - Current `main` includes the merged dependency maintenance from PRs #77 and #78. The latest observed scheduled CodeQL run on that `main` commit completed successfully.
-- `release/v0.3.0` at `493717f091c8e0c427e473c35c1db01dc7392d2f` has a successful CI run, but lacks fresh exact-SHA CodeQL, Dependency Review, Platform Readiness, and Release provider smoke evidence. It remains release-blocked.
-- Five open issues are the external validation and continuity paths listed below; there are no open pull requests at this snapshot.
+- Dependabot alert #3 (`GHSA-2v37-7h3g-55p8` / `CVE-2026-67213`) was remediated by PR #89 and is recorded by GitHub as fixed on 2026-08-31; there are no open high-severity Dependabot alerts in this snapshot.
+- Four open issues are the external validation paths listed below; there are no open pull requests at this snapshot.
 
 These are project-health and reach signals. They are **not** counted here as proof that an independent user successfully adopted the software.
 
@@ -50,9 +51,9 @@ Negative results are valid evidence. A reproducible report explaining why setup 
 
 | Category | What qualifies | Current state |
 | --- | --- | --- |
-| Release maturity | Public tagged release and runnable documented paths | Verified (`v0.2.0`) |
+| Release maturity | Public tagged release and runnable documented paths | Verified (`v0.2.0`, `v0.3.0`) |
 | Maintenance | CI/security/repository governance and tested maintainer workflows with public evidence | Verified |
-| Reach | Stars/forks observed on a stated date | 59 stars / 14 forks on 2026-08-30 |
+| Reach | Stars/forks observed on a stated date | 59 stars / 14 forks on 2026-08-31 |
 | Independent install | First-hand report from a non-maintainer with environment/version and result | None verified yet |
 | Independent workflow use | First-hand real workflow report from a non-maintainer | None verified yet |
 | External contribution | Non-maintainer issue/PR tied to genuine use or a focused improvement | None verified yet |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -84,11 +84,21 @@ The checklist-only update also remained green before merge.
 - [x] Stable tag `v0.2.0` points to the intended verified `main` commit.
 - [x] Live GitHub evidence check on 2026-08-30 found the `v0.2.0` tag but **zero GitHub Releases**. This is a tagged release line only; no GitHub Release, notes, or assets are claimed.
 
-## v0.3.0 release candidate
+## v0.3.0 release
 
-**Remote base candidate:** `493717f091c8e0c427e473c35c1db01dc7392d2f`. Its CI backend and frontend jobs succeeded, but exact-SHA CodeQL, Dependency Review, Platform Readiness, and Release provider smoke evidence are missing. The candidate is **RELEASE_BLOCKED**.
+**Verified release candidate:** `8e14e857ffbae642268ea069c9b9d1f0c72f5cdd`.
 
-Before a `release/v0.3.0 -> main` PR can be called release-ready, freeze a new exact SHA and produce a fresh evidence bundle with exactly one successful result each for CI, CodeQL, Dependency Review, Platform Readiness, and Release provider smoke. Run `scripts/release_evidence_verifier.py` against that bundle; its only passing result is the authorization to enter normal release review, not to bypass review or publish a Release automatically.
+- [x] CI — success: [run 33351296808](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296808).
+- [x] CodeQL — success: [run 33351296814](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296814).
+- [x] Dependency Review — success: [run 33351296818](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296818).
+- [x] Platform Readiness — success: [run 33351296833](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296833).
+- [x] Release provider smoke — success: [run 33351296811](https://github.com/sui-ni2/personal-ai-os/actions/runs/33351296811). This is the release-branch real-provider gate, not an ordinary PR skip.
+- [x] `scripts/release_evidence_verifier.py` returned `ready_to_tag` with no blockers using GitHub's server time.
+- [x] Release PR [#90](https://github.com/sui-ni2/personal-ai-os/pull/90) merged to `main` as `e5275ef24d5154974c324121db41bb870bac049c`.
+- [x] Annotated tag `v0.3.0` resolves to the verified candidate SHA above and is reachable from `main`.
+- [x] [GitHub Release v0.3.0](https://github.com/sui-ni2/personal-ai-os/releases/tag/v0.3.0) was published on 2026-08-31.
+
+The verifier allowed normal release review; it did not replace the repository ruleset, release-PR merge, tag validation, or publication workflow.
 
 ## Fail-closed rule
 


### PR DESCRIPTION
## Summary
- records the exact v0.3.0 candidate SHA, five release-gate URLs, verifier result, merge SHA, annotated tag, and published GitHub Release
- records Dependabot #3 as fixed and confirms no open high-severity Dependabot alerts at the observed snapshot
- refreshes the evidence ledger and Codex for OSS application evidence using 2026-08-31 repository facts

## Evidence boundary
- 59 stars, 14 forks, and CI/release activity remain reach or maintenance signals only
- `INDEPENDENT_ADOPTION_VERIFIED = 0` remains unchanged
- no product behavior, provider, plugin, UI, credentials, or generated artifacts are included