### PR TITLE
fix: close v0.4 readiness hardening

### DIFF
--- a/apps/api/src/personal_ai_os/db.py
+++ b/apps/api/src/personal_ai_os/db.py
@@ -951,6 +951,81 @@ class Database:
                 (self.tenant_id, key, value, _now()),
             )
 
+    def export_core_tenant_data(self) -> dict[str, object]:
+        """Return a portable, credential-free view of the current tenant's core database data.
+
+        This deliberately excludes connector endpoints, commands and error details because those
+        strings can contain credentials.  Project-private databases and project-native stores have
+        separate retention lifecycles and are not represented as a complete account export here.
+        """
+        queries = {
+            "user_projects": "SELECT id, name, description, created_at FROM user_projects WHERE tenant_id = ? ORDER BY created_at, id",
+            "conversations": "SELECT id, title, provider, model, project_id, created_at, updated_at FROM conversations WHERE tenant_id = ? ORDER BY created_at, id",
+            "messages": "SELECT messages.id, messages.conversation_id, messages.role, messages.content, messages.tool_refs_json, messages.created_at FROM messages JOIN conversations ON conversations.id = messages.conversation_id WHERE conversations.tenant_id = ? ORDER BY messages.created_at, messages.id",
+            "memories": "SELECT id, type, text, source, confidence, valid_from, status, project_id, created_at, updated_at, provenance_json, source_reference, conflict_key, last_used_at, why_used FROM memories WHERE tenant_id = ? ORDER BY created_at, id",
+            "artifacts": "SELECT id, kind, locator, title, metadata_json, project_id, created_at FROM artifacts WHERE tenant_id = ? ORDER BY created_at, id",
+            "repository_events": "SELECT id, event_type, summary, artifact_id, project_id, details_json, created_at FROM repository_events WHERE tenant_id = ? ORDER BY created_at, id",
+            "execution_events": "SELECT id, conversation_id, type, status, tool, duration_ms, payload_json, created_at FROM execution_events WHERE tenant_id = ? ORDER BY created_at, id",
+            "send_scope_receipts": "SELECT id, conversation_id, project_id, provider, model, selected_files_json, reviewed_memory_ids_json, tool_availability_json, context_categories_json, approximate_context_tokens, context_precision, status, created_at FROM send_scope_receipts WHERE tenant_id = ? ORDER BY created_at, id",
+            "usage_ledger": "SELECT id, conversation_id, project_id, provider, model, status, input_tokens, output_tokens, token_precision, cost_usd, cost_precision, latency_ms, created_at FROM usage_ledger WHERE tenant_id = ? ORDER BY created_at, id",
+            "budget_policies": "SELECT scope_type, scope_id, period, limit_tokens, warn_percent, hard_limit, updated_at FROM budget_policies WHERE tenant_id = ? ORDER BY scope_type, scope_id, period",
+            "budget_reservations": "SELECT id, project_id, reserved_tokens, status, reason, execution_id, expires_at, created_at, settled_at FROM budget_reservations WHERE tenant_id = ? ORDER BY created_at, id",
+            "tool_action_confirmations": "SELECT id, project_id, connector_id, tool_name, arguments_digest, preview_json, status, expires_at, created_at, confirmed_at, consumed_at, actor_id FROM tool_action_confirmations WHERE tenant_id = ? ORDER BY created_at, id",
+            "execution_runs": "SELECT id, conversation_id, project_id, provider, model, status, retry_status, side_effect_status, detail_json, created_at, updated_at FROM execution_runs WHERE tenant_id = ? ORDER BY created_at, id",
+            "settings": "SELECT key, value, updated_at FROM tenant_settings WHERE tenant_id = ? AND key IN ('default_provider', 'default_model', 'routing_policy', 'fallback_provider', 'fallback_model') ORDER BY key",
+            "connector_metadata": "SELECT id, name, transport, enabled, allowed_tools_json, connection_status, timeout_seconds, created_at, updated_at FROM mcp_connectors WHERE tenant_id = ? ORDER BY created_at, id",
+        }
+        with self.connect() as connection:
+            data = {
+                name: [dict(row) for row in connection.execute(query, (self.tenant_id,)).fetchall()]
+                for name, query in queries.items()
+            }
+        return {
+            "format": "personal-ai-os-core-data-export-v1",
+            "credentials_included": False,
+            "excluded_scopes": [
+                "provider credentials and authentication secrets",
+                "connector endpoints, commands, and error details",
+                "private project-state databases and recovery metadata",
+                "project-native data stores, workspace files, and backup archives",
+            ],
+            "data": data,
+        }
+
+    def erase_core_tenant_data(self) -> dict[str, int]:
+        """Atomically remove core database records for the active tenant only.
+
+        The caller is responsible for explicit confirmation and for presenting the excluded
+        filesystem scopes before invoking this operation.
+        """
+        statements = (
+            ("messages", "DELETE FROM messages WHERE conversation_id IN (SELECT id FROM conversations WHERE tenant_id = ? )"),
+            ("execution_events", "DELETE FROM execution_events WHERE tenant_id = ?"),
+            ("send_scope_receipts", "DELETE FROM send_scope_receipts WHERE tenant_id = ?"),
+            ("usage_ledger", "DELETE FROM usage_ledger WHERE tenant_id = ?"),
+            ("budget_reservations", "DELETE FROM budget_reservations WHERE tenant_id = ?"),
+            ("budget_policies", "DELETE FROM budget_policies WHERE tenant_id = ?"),
+            ("tool_action_confirmations", "DELETE FROM tool_action_confirmations WHERE tenant_id = ?"),
+            ("execution_runs", "DELETE FROM execution_runs WHERE tenant_id = ?"),
+            ("mcp_connectors", "DELETE FROM mcp_connectors WHERE tenant_id = ?"),
+            ("memories", "DELETE FROM memories WHERE tenant_id = ?"),
+            ("artifacts", "DELETE FROM artifacts WHERE tenant_id = ?"),
+            ("repository_events", "DELETE FROM repository_events WHERE tenant_id = ?"),
+            ("user_projects", "DELETE FROM user_projects WHERE tenant_id = ?"),
+            ("tenant_settings", "DELETE FROM tenant_settings WHERE tenant_id = ?"),
+            ("tenant_entitlements", "DELETE FROM tenant_entitlements WHERE tenant_id = ?"),
+            ("conversations", "DELETE FROM conversations WHERE tenant_id = ?"),
+        )
+        with self.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            deleted = {
+                name: connection.execute(statement, (self.tenant_id,)).rowcount
+                for name, statement in statements
+            }
+            if self.tenant_id == "local":
+                deleted["legacy_app_settings"] = connection.execute("DELETE FROM app_settings").rowcount
+        return deleted
+
     def sync_entitlements(self, values: dict[str, bool]) -> None:
         now = _now()
         with self.connect() as connection:

--- a/apps/api/src/personal_ai_os/project_state.py
+++ b/apps/api/src/personal_ai_os/project_state.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
+import os
 import sqlite3
+import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -24,13 +27,30 @@ def _now() -> str:
 
 
 def _safe_project_id(project_id: str) -> str:
-    if not project_id or any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-" for ch in project_id):
+    if (
+        not project_id
+        or project_id in {".", ".."}
+        or any(
+            ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+            for ch in project_id
+        )
+    ):
         raise ValueError("project_id contains unsupported path characters")
     return project_id
 
 
 def _tenant_scope(tenant_id: str) -> str:
     return hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()[:16]
+
+
+def _project_storage_key(project_id: str) -> str:
+    """Return a 128-bit opaque on-disk key for a validated project identifier.
+
+    Keeping the key compact avoids exceeding the Windows legacy path limit in deep data roots
+    while retaining a collision space far beyond the supported project-registry cardinality.
+    """
+    digest = hashlib.sha256(project_id.encode("utf-8")).digest()[:16]
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
 
 class ProjectStateConflict(RuntimeError):
@@ -57,7 +77,7 @@ class ProjectStateService:
     """Private, project-scoped continuity state with physical project isolation.
 
     Public source code defines the protocol only. Runtime values are stored in a separate SQLite
-    database for each project under ``data/private/project-state``. The main repository database is
+    database for each project under ``data/private/p``. The main repository database is
     used only for audit events, so project state does not leak into the generic Memory listing.
     """
 
@@ -74,18 +94,85 @@ class ProjectStateService:
 
     def storage_path(self, project_id: str) -> Path:
         project = _safe_project_id(project_id)
-        return (
-            self.data_dir
-            / "private"
-            / "project-state"
-            / _tenant_scope(self.tenant_id)
-            / project
-            / "state.sqlite3"
+        return self._storage_root() / _project_storage_key(project) / "s.db"
+
+    def _storage_root(self) -> Path:
+        # Keep the fixed segments compact: SQLite also creates journal/WAL files beside the database,
+        # and deep Windows data roots otherwise exceed the legacy path-length limit.
+        return self.data_dir / "private" / "p" / _tenant_scope(self.tenant_id)
+
+    def _legacy_storage_root(self) -> Path:
+        return self.data_dir / "private" / "project-state" / _tenant_scope(self.tenant_id)
+
+    def _legacy_storage_path(self, project_id: str) -> Path | None:
+        """Find a pre-v0.4 private database without constructing a path from user input.
+
+        Older releases used the project identifier as a directory name.  We inspect only direct
+        children of the fixed tenant root, resolve each candidate, and reject a symlink that
+        escapes that root.  The identifier is used solely as a filename comparison.
+        """
+        root = self._legacy_storage_root()
+        if not root.is_dir():
+            return None
+        resolved_root = root.resolve()
+        for candidate in root.iterdir():
+            if candidate.name != project_id or not candidate.is_dir():
+                continue
+            resolved_candidate = candidate.resolve()
+            if resolved_candidate.parent != resolved_root:
+                return None
+            database = resolved_candidate / "state.sqlite3"
+            if not database.is_file():
+                return None
+            resolved_database = database.resolve()
+            if resolved_database.parent != resolved_candidate:
+                return None
+            return resolved_database
+        return None
+
+    @staticmethod
+    def _copy_database_once(source: Path, target: Path) -> None:
+        """Copy a legacy SQLite database atomically, preserving the original as a rollback source."""
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            return
+
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix="m-", suffix="", dir=target.parent
         )
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        try:
+            source_connection = sqlite3.connect(source)
+            target_connection = sqlite3.connect(temporary)
+            try:
+                source_connection.backup(target_connection)
+            finally:
+                # sqlite3.Connection's context manager commits but does not close.  Close both
+                # handles before publishing and unlinking on Windows.
+                target_connection.close()
+                source_connection.close()
+            try:
+                # A hard link is an atomic no-overwrite publish on the same volume.  A concurrent
+                # initializer that won the race keeps its database; both copies have the same source.
+                os.link(temporary, target)
+            except FileExistsError:
+                return
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _preserve_legacy_storage(self, project_id: str, target: Path) -> None:
+        if target.exists():
+            return
+        legacy = self._legacy_storage_path(project_id)
+        if legacy is not None:
+            self._copy_database_once(legacy, target)
 
     @contextmanager
     def _connect(self, project_id: str) -> Iterator[sqlite3.Connection]:
-        path = self.storage_path(project_id)
+        project = _safe_project_id(project_id)
+        path = self.storage_path(project)
+        self._preserve_legacy_storage(project, path)
         path.parent.mkdir(parents=True, exist_ok=True)
         connection = sqlite3.connect(path, timeout=10)
         connection.row_factory = sqlite3.Row

--- a/apps/api/src/personal_ai_os/routes.py
+++ b/apps/api/src/personal_ai_os/routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import aclosing
 import json
+import os
 import re
 import sqlite3
 from typing import Annotated
@@ -20,6 +21,7 @@ from .runtime import Runtime
 from .schemas import (
     ArtifactCreate,
     ChatRequest,
+    CoreDataEraseRequest,
     ConversationCreate,
     MCPConnectorCreate,
     MCPConnectorUpdate,
@@ -283,6 +285,74 @@ def project_detail(project_id: str, request: Request) -> dict[str, object]:
         return runtime_from(request).projects.describe(project_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/doctor")
+def doctor_report(request: Request) -> dict[str, object]:
+    """Produce a support-safe browser report without exposing runtime values or paths."""
+    runtime = runtime_from(request)
+    try:
+        with runtime.database.connect() as connection:
+            integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+            migration_version = int(
+                connection.execute("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").fetchone()[0]
+            )
+        database = {
+            "status": "ok" if integrity == "ok" else "attention",
+            "integrity": integrity if integrity == "ok" else "attention",
+            "migration_version": migration_version,
+        }
+    except sqlite3.Error:
+        database = {"status": "attention", "integrity": "unavailable", "migration_version": None}
+
+    data_dir = runtime.settings.data_dir
+    recovery_dir = data_dir / "recovery"
+    return {
+        "report": "personal-ai-os-doctor-browser-v1",
+        "safe_to_share": True,
+        "redaction": "Credential values, headers, cookies, paths, conversations, memory text, project state, and provider responses are excluded.",
+        "database": database,
+        "data_directory": {
+            "exists": data_dir.is_dir(),
+            "writable": os.access(data_dir if data_dir.exists() else data_dir.parent, os.W_OK),
+        },
+        "providers": {
+            "configured": {item["id"]: bool(item["configured"]) for item in runtime.providers.describe()},
+            "values_exposed": False,
+        },
+        "projects": {"registered_count": len(runtime.projects.list()), "names_exposed": False},
+        "recovery": {
+            "metadata_file_count": len(list(recovery_dir.glob("*.sqlite3"))) if recovery_dir.is_dir() else 0,
+            "details_exposed": False,
+        },
+        "limitations": [
+            "This browser report does not validate a live provider request.",
+            "Windows signing, Docker Desktop, physical devices, and screen readers require separate external validation.",
+        ],
+    }
+
+
+@router.get("/data/core-export")
+def export_core_data(request: Request) -> dict[str, object]:
+    return runtime_from(request).database.export_core_tenant_data()
+
+
+@router.post("/data/core-erase")
+def erase_core_data(payload: CoreDataEraseRequest, request: Request) -> dict[str, object]:
+    runtime = runtime_from(request)
+    user_project_ids = [item.id for item in runtime.database.list_user_projects()]
+    deleted = runtime.database.erase_core_tenant_data()
+    for project_id in user_project_ids:
+        runtime.projects.unregister(project_id)
+    return {
+        "status": "core_data_erased",
+        "deleted": deleted,
+        "retained_scopes": [
+            "private project-state databases and recovery metadata",
+            "project-native data stores, workspace files, and backup archives",
+            "server-side provider credentials and access-control configuration",
+        ],
+    }
 
 
 @router.get("/conversations")

--- a/apps/api/src/personal_ai_os/schemas.py
+++ b/apps/api/src/personal_ai_os/schemas.py
@@ -251,3 +251,8 @@ class MCPConnectorUpdate(BaseModel):
 class SettingsUpdate(BaseModel):
     default_provider: str | None = None
     default_model: str | None = None
+
+
+class CoreDataEraseRequest(BaseModel):
+    confirmation: Literal["ERASE_CORE_DATA"]
+    export_acknowledged: Literal[True]

--- a/apps/api/tests/test_data_lifecycle.py
+++ b/apps/api/tests/test_data_lifecycle.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+from personal_ai_os_core import MessageRole
+
+
+def test_core_data_export_is_scoped_and_credential_free(client: TestClient, runtime) -> None:
+    created_project = client.post(
+        "/api/projects",
+        json={"name": "Export fixture", "description": "A user-owned project for export coverage."},
+    )
+    assert created_project.status_code == 201
+    project_id = created_project.json()["id"]
+    conversation = runtime.database.create_conversation(
+        provider="openai", model="openai-test", project_id=project_id, title="Export fixture"
+    )
+    runtime.database.add_message(conversation.id, MessageRole.USER, "Portable conversation content")
+    created_memory = client.post(
+        "/api/memory",
+        json={
+            "type": "fact",
+            "text": "Portable memory content",
+            "source": "test",
+            "confidence": 1,
+            "project_id": project_id,
+        },
+    )
+    assert created_memory.status_code == 201
+    runtime.database.set_setting("internal_settings_marker", "not-exported")
+
+    response = client.get("/api/data/core-export")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["format"] == "personal-ai-os-core-data-export-v1"
+    assert payload["credentials_included"] is False
+    assert payload["data"]["conversations"][0]["id"] == conversation.id
+    assert payload["data"]["messages"][0]["content"] == "Portable conversation content"
+    assert payload["data"]["memories"][0]["text"] == "Portable memory content"
+    assert "internal_settings_marker" not in str(payload)
+    assert "connector endpoints" in " ".join(payload["excluded_scopes"])
+
+
+def test_core_data_erase_requires_acknowledgement_and_preserves_static_projects(
+    client: TestClient, runtime
+) -> None:
+    created_project = client.post(
+        "/api/projects",
+        json={"name": "Erase fixture", "description": "A user-owned project for erase coverage."},
+    )
+    assert created_project.status_code == 201
+    project_id = created_project.json()["id"]
+    runtime.database.create_memory(
+        {
+            "type": "fact",
+            "text": "This record is intentionally erased by the test.",
+            "source": "test",
+            "confidence": 1,
+            "project_id": project_id,
+        }
+    )
+
+    missing_acknowledgement = client.post(
+        "/api/data/core-erase", json={"confirmation": "ERASE_CORE_DATA", "export_acknowledged": False}
+    )
+    assert missing_acknowledgement.status_code == 422
+
+    erased = client.post(
+        "/api/data/core-erase", json={"confirmation": "ERASE_CORE_DATA", "export_acknowledged": True}
+    )
+
+    assert erased.status_code == 200
+    assert erased.json()["status"] == "core_data_erased"
+    assert runtime.database.list_user_projects() == []
+    assert runtime.database.list_memories() == []
+    assert runtime.projects.get("general").metadata.id == "general"
+    try:
+        runtime.projects.get(project_id)
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("Erased user project remained registered in the active runtime")
+    assert "private project-state databases" in " ".join(erased.json()["retained_scopes"])
+
+
+def test_browser_doctor_report_is_safe_to_share(client: TestClient) -> None:
+    response = client.get("/api/doctor")
+
+    assert response.status_code == 200
+    report = response.json()
+    serialized = json.dumps(report)
+    assert report["safe_to_share"] is True
+    assert report["providers"]["values_exposed"] is False
+    assert report["projects"]["names_exposed"] is False
+    assert "tenant_id" not in serialized
+    assert "credential values" in report["redaction"].lower()

--- a/apps/api/tests/test_project_state.py
+++ b/apps/api/tests/test_project_state.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import sqlite3
 from collections.abc import AsyncIterator
 
 from fastapi.testclient import TestClient
@@ -53,9 +56,61 @@ def test_project_state_uses_separate_private_database_per_project(runtime) -> No
 
     assert general_path != p5_path != soccer_path
     assert "private" in general_path.parts
-    assert general_path.name == "state.sqlite3"
-    assert p5_path.name == "state.sqlite3"
-    assert soccer_path.name == "state.sqlite3"
+    assert general_path.name == "s.db"
+    assert p5_path.name == "s.db"
+    assert soccer_path.name == "s.db"
+    assert general_path.parent.name == base64.urlsafe_b64encode(
+        hashlib.sha256(b"general").digest()[:16]
+    ).decode("ascii").rstrip("=")
+    assert "general" not in general_path.parts
+
+
+def test_project_state_migrates_legacy_raw_directory_without_deleting_it(runtime) -> None:
+    service = ProjectStateService(runtime.database)
+    legacy_path = (
+        runtime.settings.data_dir
+        / "private"
+        / "project-state"
+        / hashlib.sha256(runtime.settings.tenant_id.encode("utf-8")).hexdigest()[:16]
+        / "general"
+        / "state.sqlite3"
+    )
+    legacy_path.parent.mkdir(parents=True)
+    with sqlite3.connect(legacy_path) as connection:
+        service._migrate(connection)
+        connection.execute(
+            "INSERT INTO current_state(namespace, key, value_json, source, confidence, version, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "workflow",
+                "legacy",
+                '{"preserved":true}',
+                "legacy-fixture",
+                1,
+                1,
+                "active",
+                "2026-09-02T00:00:00+00:00",
+                "2026-09-02T00:00:00+00:00",
+            ),
+        )
+
+    states = service.list_state("general")
+
+    assert states[0]["value"] == {"preserved": True}
+    assert legacy_path.exists()
+    assert service.storage_path("general").exists()
+    assert service.storage_path("general") != legacy_path
+
+
+def test_project_state_rejects_path_segments(runtime) -> None:
+    service = ProjectStateService(runtime.database)
+
+    for project_id in (".", "..", "../general", "general/other"):
+        try:
+            service.storage_path(project_id)
+        except ValueError:
+            continue
+        raise AssertionError(f"{project_id!r} was accepted as a project storage identifier")
 
 def test_project_state_upsert_keeps_one_current_value_and_history(client: TestClient) -> None:
     first = client.put(

--- a/apps/api/tests/test_project_workflow.py
+++ b/apps/api/tests/test_project_workflow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 from collections.abc import AsyncIterator
 
 from fastapi.testclient import TestClient
@@ -130,8 +132,12 @@ def test_workflow_storage_is_physically_project_scoped(runtime) -> None:
         tenant_id=runtime.settings.tenant_id,
     )
     assert service.storage_path("soccer") != service.storage_path("p5")
-    assert service.storage_path("soccer").parent.name == "soccer"
-    assert service.storage_path("p5").parent.name == "p5"
+    assert service.storage_path("soccer").parent.name == base64.urlsafe_b64encode(
+        hashlib.sha256(b"soccer").digest()[:16]
+    ).decode("ascii").rstrip("=")
+    assert service.storage_path("p5").parent.name == base64.urlsafe_b64encode(
+        hashlib.sha256(b"p5").digest()[:16]
+    ).decode("ascii").rstrip("=")
 
 
 def test_workflow_does_not_leak_into_generic_memory(client: TestClient) -> None:

--- a/apps/api/tests/test_v04_state_growth_soak.py
+++ b/apps/api/tests/test_v04_state_growth_soak.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from personal_ai_os.governance import GovernanceService, _arguments_digest
+from personal_ai_os.project_recovery import ProjectRecoveryService
+from personal_ai_os.project_state import ProjectStateService
+from personal_ai_os.project_workflow import ProjectWorkflowService
+
+
+RECORD_COUNT = 120
+WORKFLOW_COUNT = 40
+
+
+def _backup_and_restore_count(source_path, restored_path) -> int:
+    source = sqlite3.connect(source_path)
+    target = sqlite3.connect(restored_path)
+    try:
+        source.backup(target)
+    finally:
+        target.close()
+        source.close()
+    restored = sqlite3.connect(restored_path)
+    try:
+        return int(restored.execute("SELECT COUNT(*) FROM usage_ledger").fetchone()[0])
+    finally:
+        restored.close()
+
+
+def test_v04_state_growth_soak_is_bounded_and_recovers_cleanly(runtime, tmp_path) -> None:
+    """Exercise hundreds of synthetic records without a provider, credential, or user workspace."""
+    runtime.database.migrate()
+    project_id = "general"
+    state = ProjectStateService(
+        runtime.database, data_dir=runtime.settings.data_dir, tenant_id=runtime.settings.tenant_id
+    )
+    workflow = ProjectWorkflowService(
+        runtime.database, data_dir=runtime.settings.data_dir, tenant_id=runtime.settings.tenant_id
+    )
+    governance = GovernanceService(runtime.database)
+    governance.set_budget_policy(
+        {
+            "scope_type": "project",
+            "scope_id": project_id,
+            "period": "daily",
+            "limit_tokens": 100_000,
+            "warn_percent": 80,
+            "hard_limit": True,
+        }
+    )
+
+    for index in range(RECORD_COUNT):
+        namespace = ("goal", "task", "decision", "outcome")[index % 4]
+        state.put_state(
+            project_id=project_id,
+            namespace=namespace,
+            key=f"soak-{index}",
+            value={"fixture": index, "status": "synthetic"},
+            source="v0.4-state-growth-soak",
+            expected_version=0,
+        )
+        state.append_experience(
+            project_id=project_id,
+            namespace="soak",
+            text=f"Synthetic bounded experience {index}",
+            source="v0.4-state-growth-soak",
+            confidence=1,
+        )
+        runtime.database.create_memory(
+            {
+                "type": "fact",
+                "text": f"Synthetic memory {index}",
+                "source": "v0.4-state-growth-soak",
+                "confidence": 1,
+                "project_id": project_id,
+            }
+        )
+        governance.save_send_scope(
+            {
+                "project_id": project_id,
+                "provider": "fixture-provider",
+                "model": "fixture-model",
+                "selected_files": [],
+                "reviewed_memory_ids": [],
+                "tool_availability": [],
+                "context_categories": ["user_message", "project_metadata"],
+                "approximate_context_tokens": 1,
+                "context_precision": "ESTIMATED",
+            },
+            conversation_id=None,
+            status="succeeded",
+        )
+        reservation = governance.reserve_budget(project_id, tokens=1, reason="v0.4-state-growth-soak")
+        assert reservation["blocked"] is False
+        governance.settle_budget_reservation(
+            reservation["reservation_id"], status="committed" if index % 2 else "released"
+        )
+        governance.record_usage(
+            conversation_id="soak-conversation",
+            project_id=project_id,
+            provider="fixture-provider",
+            model="fixture-model",
+            input_tokens=1,
+            output_tokens=1,
+            status="succeeded",
+            latency_ms=1,
+        )
+
+    for index in range(WORKFLOW_COUNT):
+        created = workflow.create_workflow(
+            project_id=project_id,
+            workflow_id=f"soak-workflow-{index}",
+            run_key="run",
+            steps=["prepare", "complete"],
+            source="v0.4-state-growth-soak",
+        )
+        advanced = workflow.advance_workflow(
+            project_id=project_id,
+            workflow_id=created["workflow_id"],
+            run_key=created["run_key"],
+            next_step="prepare",
+            expected_version=created["version"],
+            evidence={"fixture": index},
+            source="v0.4-state-growth-soak",
+        )
+        assert advanced["next_step"] == "complete"
+
+    confirmation_id = "v04-soak-confirmation"
+    arguments = {"fixture": "approved"}
+    now = datetime.now(timezone.utc)
+    with runtime.database.connect() as connection:
+        connection.execute(
+            "INSERT INTO tool_action_confirmations(id, tenant_id, actor_id, project_id, connector_id, tool_name, arguments_digest, preview_json, status, expires_at, created_at, confirmed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, '{}', 'confirmed', ?, ?, ?)",
+            (
+                confirmation_id,
+                runtime.database.tenant_id,
+                runtime.database.actor_id,
+                project_id,
+                "soak-connector",
+                "external.fixture",
+                _arguments_digest(arguments),
+                (now + timedelta(minutes=10)).isoformat(),
+                now.isoformat(),
+                now.isoformat(),
+            ),
+        )
+    assert governance.consume_tool_confirmation(
+        confirmation_id=confirmation_id,
+        project_id=project_id,
+        connector_id="soak-connector",
+        tool_name="external.fixture",
+        arguments=arguments,
+    )
+    assert not governance.consume_tool_confirmation(
+        confirmation_id=confirmation_id,
+        project_id=project_id,
+        connector_id="soak-connector",
+        tool_name="external.fixture",
+        arguments=arguments,
+    )
+
+    recovery = ProjectRecoveryService(
+        runtime.database, data_dir=runtime.settings.data_dir, tenant_id=runtime.settings.tenant_id
+    )
+    session = recovery.start_session(project_id)
+    checkpoint = recovery.checkpoint(
+        project_id, session["session_id"], expected_version=session["recovery_version"]
+    )
+    closed = recovery.close_session(
+        project_id, session["session_id"], expected_version=checkpoint["recovery_version"]
+    )
+    assert closed["status"] == "clean"
+    assert recovery.inspect(project_id)["status"] == "clean"
+
+    restored_usage_count = _backup_and_restore_count(
+        runtime.database.path, tmp_path / "v04-state-growth-backup.sqlite3"
+    )
+    with runtime.database.connect() as connection:
+        migration_version = connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0]
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+        active_reservations = connection.execute(
+            "SELECT COUNT(*) FROM budget_reservations WHERE tenant_id = ? AND status = 'active'",
+            (runtime.database.tenant_id,),
+        ).fetchone()[0]
+        usage_count, usage_distinct = connection.execute(
+            "SELECT COUNT(*), COUNT(DISTINCT id) FROM usage_ledger WHERE tenant_id = ?",
+            (runtime.database.tenant_id,),
+        ).fetchone()
+        receipt_count = connection.execute(
+            "SELECT COUNT(*) FROM send_scope_receipts WHERE tenant_id = ?", (runtime.database.tenant_id,)
+        ).fetchone()[0]
+        event_count = connection.execute(
+            "SELECT COUNT(*) FROM repository_events WHERE tenant_id = ?", (runtime.database.tenant_id,)
+        ).fetchone()[0]
+
+    assert migration_version == 8
+    assert integrity == "ok"
+    assert active_reservations == 0
+    assert usage_count == usage_distinct == RECORD_COUNT
+    assert restored_usage_count == RECORD_COUNT
+    assert receipt_count == RECORD_COUNT
+    assert len(state.list_state(project_id)) == RECORD_COUNT
+    assert len(state.list_experience(project_id)) == RECORD_COUNT
+    assert len(runtime.database.list_memories()) == RECORD_COUNT
+    assert len(workflow.list_workflows(project_id)) == WORKFLOW_COUNT
+    assert RECORD_COUNT * 2 + WORKFLOW_COUNT * 2 <= event_count <= RECORD_COUNT * 3

--- a/apps/web/components/settings-governance-panel.tsx
+++ b/apps/web/components/settings-governance-panel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
-import { AlertTriangle, Check, DatabaseBackup, ShieldCheck, WalletCards } from "lucide-react";
+import { AlertTriangle, Check, DatabaseBackup, Download, HeartPulse, ShieldCheck, Trash2, WalletCards } from "lucide-react";
 import { apiJson } from "@/lib/api";
 
 type Provider = { id: string; configured: boolean; models: string[] };
 type Usage = { items: { provider: string; model: string; requests: number; input_tokens: number; output_tokens: number; token_precision: string; cost_precision: string; latency_ms: number }[] };
 type Budget = { policies: { period: string; limit_tokens: number; used_tokens: number; warn: boolean; blocked: boolean }[] };
 type Routing = { policy: "STRICT_PROVIDER" | "FALLBACK_ALLOWED" | "ASK_BEFORE_FALLBACK"; fallback_provider?: string; fallback_model?: string };
+type DoctorReport = { safe_to_share: boolean; database: { status: string; migration_version: number | null } };
 
 export function SettingsGovernancePanel({ providers }: { providers: Provider[] }) {
   const [usage, setUsage] = useState<Usage>({ items: [] });
@@ -17,6 +18,9 @@ export function SettingsGovernancePanel({ providers }: { providers: Provider[] }
   const [limitTokens, setLimitTokens] = useState("100000");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState("");
+  const [lifecycleNotice, setLifecycleNotice] = useState("");
+  const [lifecycleBusy, setLifecycleBusy] = useState(false);
+  const [eraseConfirmation, setEraseConfirmation] = useState("");
   const configured = providers.filter((item) => item.configured);
 
   async function load() {
@@ -56,17 +60,62 @@ export function SettingsGovernancePanel({ providers }: { providers: Provider[] }
     } finally { setSaving(false); }
   }
 
+  function downloadJson(filename: string, value: object) {
+    const url = window.URL.createObjectURL(new Blob([JSON.stringify(value, null, 2)], { type: "application/json" }));
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    window.setTimeout(() => window.URL.revokeObjectURL(url), 0);
+  }
+
+  async function downloadCoreExport() {
+    setLifecycleBusy(true);
+    try {
+      downloadJson("personal-ai-os-core-data-export.json", await apiJson<object>("/api/data/core-export"));
+      setLifecycleNotice("Core data export downloaded. Review its excluded scopes before any erase.");
+    } catch {
+      setLifecycleNotice("Core data export could not be created. Your local data was not changed.");
+    } finally { setLifecycleBusy(false); }
+  }
+
+  async function downloadDoctorReport() {
+    setLifecycleBusy(true);
+    try {
+      const report = await apiJson<DoctorReport>("/api/doctor");
+      downloadJson("personal-ai-os-doctor-safe-report.json", report);
+      setLifecycleNotice(report.safe_to_share ? "Redacted Doctor report downloaded." : "Doctor report was not marked safe to share.");
+    } catch {
+      setLifecycleNotice("Doctor report could not be created. Your local data was not changed.");
+    } finally { setLifecycleBusy(false); }
+  }
+
+  async function eraseCoreData() {
+    if (eraseConfirmation !== "ERASE_CORE_DATA" || lifecycleBusy) return;
+    if (!window.confirm("Erase core conversations, memory, project metadata, usage, governance receipts, and connector metadata? Private project databases, files, backups, and credentials will remain.")) return;
+    setLifecycleBusy(true);
+    try {
+      await apiJson("/api/data/core-erase", { method: "POST", body: JSON.stringify({ confirmation: "ERASE_CORE_DATA", export_acknowledged: true }) });
+      setEraseConfirmation("");
+      setLifecycleNotice("Core database data was erased. The retained scopes are listed below.");
+      await load();
+    } catch {
+      setLifecycleNotice("Core data erase was not completed. Review the export and local API status before retrying.");
+    } finally { setLifecycleBusy(false); }
+  }
+
   return (
     <section id="privacy-usage-settings" className="scroll-mt-6 space-y-4" aria-labelledby="privacy-usage-title">
       <div className="flex items-center gap-2"><ShieldCheck aria-hidden size={18} className="text-text-tertiary" /><h2 id="privacy-usage-title" className="section-title">Memory, privacy, usage & budget</h2></div>
       <div className="grid gap-4 lg:grid-cols-2">
         <article className="panel p-4 sm:p-5"><h3 className="text-[15px] font-medium">Memory & privacy</h3><p className="mt-2 text-sm leading-6 text-text-secondary">Long-term Memory is explicit, project-scoped or global, and separate from Outcomes. A send-scope receipt lists the project, provider, reviewed-memory references, tools, and estimated context size for every text request. Secrets and hidden reasoning are excluded.</p><a className="button-quiet mt-4 px-0 text-accent-hover" href="/memory">Review retained memory</a></article>
-        <article className="panel p-4 sm:p-5"><h3 className="text-[15px] font-medium">Projects & data</h3><p className="mt-2 text-sm leading-6 text-text-secondary">Project state, files, decisions and Outcomes remain in the local workspace. Provider sessions are not copied when switching models. Export and restore exclude provider credentials.</p><a className="button-quiet mt-4 px-0 text-accent-hover" href="/repository">Review files and activity</a></article>
+        <article className="panel p-4 sm:p-5"><h3 className="text-[15px] font-medium">Core data export & erase</h3><p className="mt-2 text-sm leading-6 text-text-secondary">Download the portable core database before erasing it. Credentials, connector targets, private project state, project-native stores, files, and backup archives are excluded and are never claimed as erased by this control.</p><div className="mt-4 flex flex-wrap gap-3"><button type="button" className="button-quiet px-0 text-accent-hover" onClick={() => void downloadCoreExport()} disabled={lifecycleBusy}><Download aria-hidden size={15} />Download core export</button><a className="button-quiet px-0 text-accent-hover" href="/repository">Review files and activity</a></div><label className="mt-4 block text-xs font-medium text-text-secondary">Type <code>ERASE_CORE_DATA</code> to erase only the core database<input className="field mt-1.5 w-full" aria-label="Core data erase confirmation" value={eraseConfirmation} onChange={(event) => setEraseConfirmation(event.target.value)} autoComplete="off" /></label><button type="button" className="button-secondary mt-2 text-danger" onClick={() => void eraseCoreData()} disabled={lifecycleBusy || eraseConfirmation !== "ERASE_CORE_DATA"}><Trash2 aria-hidden size={15} />Erase core data</button></article>
         <article className="panel p-4 sm:p-5"><div className="flex items-center gap-2"><WalletCards aria-hidden size={17} className="text-text-tertiary" /><h3 className="text-[15px] font-medium">Usage & budget</h3></div><p className="mt-2 text-xs leading-5 text-text-secondary">Token figures are estimated unless a provider supplies reliable usage. Provider cost is shown as unknown until it is reliable; it is never presented as a bill.</p>{usage.items.length ? <dl className="mt-4 space-y-2 text-sm">{usage.items.map((item) => <div key={`${item.provider}-${item.model}`} className="flex justify-between gap-3 rounded-small bg-surface-subtle px-3 py-2"><dt>{item.provider} / {item.model}</dt><dd className="text-text-secondary">{item.requests} requests · {item.input_tokens + item.output_tokens} {item.token_precision.toLowerCase()} tokens</dd></div>)}</dl> : <p className="mt-4 text-sm text-text-tertiary">No usage recorded yet.</p>}<form className="mt-4 grid gap-2 sm:grid-cols-[1fr_1fr_auto]" onSubmit={saveBudget}><select className="field" aria-label="Budget period" value={period} onChange={(event) => setPeriod(event.target.value)}><option value="daily">Daily</option><option value="weekly">Weekly</option><option value="monthly">Monthly</option></select><input className="field" aria-label="Estimated token limit" type="number" min="1" value={limitTokens} onChange={(event) => setLimitTokens(event.target.value)} /><button className="button-secondary" disabled={saving}>{saving ? "Saving…" : "Set hard limit"}</button></form>{budget.policies.map((item) => <p key={item.period} className={`mt-2 text-xs ${item.blocked ? "text-danger" : item.warn ? "text-warning" : "text-text-tertiary"}`}>{item.period}: {item.used_tokens}/{item.limit_tokens} estimated tokens{item.blocked ? " · requests stopped" : ""}</p>)}</article>
         <article className="panel p-4 sm:p-5"><h3 className="text-[15px] font-medium">Provider routing</h3><p className="mt-2 text-xs leading-5 text-text-secondary">Fallback preserves authorized workspace context only. Any tool action stays on the selected provider and requires a new confirmation.</p><form className="mt-4 grid gap-3" onSubmit={saveRouting}><label className="text-xs font-medium text-text-secondary">Policy<select className="field mt-1.5 w-full" value={routing.policy} onChange={(event) => setRouting((current) => ({ ...current, policy: event.target.value as Routing["policy"] }))}><option value="STRICT_PROVIDER">Strict provider</option><option value="FALLBACK_ALLOWED">Fallback allowed</option><option value="ASK_BEFORE_FALLBACK">Ask before fallback</option></select></label>{routing.policy !== "STRICT_PROVIDER" && <div className="grid gap-2 sm:grid-cols-2"><label className="text-xs font-medium text-text-secondary">Fallback service<select className="field mt-1.5 w-full" value={routing.fallback_provider || ""} onChange={(event) => { const next = configured.find((item) => item.id === event.target.value); setRouting((current) => ({ ...current, fallback_provider: event.target.value || undefined, fallback_model: next?.models[0] })); }}><option value="">Choose service</option>{configured.map((item) => <option key={item.id} value={item.id}>{item.id}</option>)}</select></label><label className="text-xs font-medium text-text-secondary">Fallback model<select className="field mt-1.5 w-full" value={routing.fallback_model || ""} onChange={(event) => setRouting((current) => ({ ...current, fallback_model: event.target.value || undefined }))}><option value="">Choose model</option>{configured.find((item) => item.id === routing.fallback_provider)?.models.map((model) => <option key={model} value={model}>{model}</option>)}</select></label></div>}<button className="button-secondary" disabled={saving}>{saving ? "Saving…" : "Save routing"}</button></form></article>
-        <article className="panel p-4 sm:p-5 lg:col-span-2"><div className="flex items-center gap-2"><DatabaseBackup aria-hidden size={17} className="text-text-tertiary" /><h3 className="text-[15px] font-medium">Backup, restore & diagnostics</h3></div><p className="mt-2 text-sm leading-6 text-text-secondary">Before a restore or update, create a verified data backup. Backup archives never include provider credentials. The local Doctor command produces a safe-to-share, redacted health report.</p><div className="mt-3 flex flex-wrap gap-3"><a className="button-quiet px-0 text-accent-hover" href="https://github.com/sui-ni2/personal-ai-os/blob/main/docs/transfer-and-backup.md">Backup & restore guide</a><span className="text-xs text-text-tertiary">Diagnostics: runtime, data, migrations, provider state and recovery without secrets.</span></div></article>
+        <article className="panel p-4 sm:p-5 lg:col-span-2"><div className="flex items-center gap-2"><DatabaseBackup aria-hidden size={17} className="text-text-tertiary" /><h3 className="text-[15px] font-medium">Backup, restore & diagnostics</h3></div><p className="mt-2 text-sm leading-6 text-text-secondary">Before a restore or update, create a verified data backup. Backup archives never include provider credentials. Doctor reports database integrity, migration status, safe configuration booleans, and recovery metadata counts without exposing their contents.</p><div className="mt-3 flex flex-wrap gap-3"><a className="button-quiet px-0 text-accent-hover" href="https://github.com/sui-ni2/personal-ai-os/blob/main/docs/transfer-and-backup.md">Backup & restore guide</a><a className="button-quiet px-0 text-accent-hover" href="https://github.com/sui-ni2/personal-ai-os/blob/main/docs/windows-distribution.md">Windows update & rollback</a><button type="button" className="button-quiet px-0 text-accent-hover" onClick={() => void downloadDoctorReport()} disabled={lifecycleBusy}><HeartPulse aria-hidden size={15} />Download safe Doctor report</button><span className="text-xs text-text-tertiary">Windows signing, Docker, physical devices, and screen readers remain separate external checks.</span></div></article>
       </div>
       {saved && <p className="flex items-center gap-2 text-sm text-success" role="status"><Check aria-hidden size={15} />{saved}</p>}
+      {lifecycleNotice && <p className="flex items-center gap-2 text-sm text-text-secondary" role="status"><Check aria-hidden size={15} />{lifecycleNotice}</p>}
       <p className="flex items-center gap-2 text-xs text-text-tertiary"><AlertTriangle aria-hidden size={14} />Advanced connector, repository and execution-trace controls remain in Advanced mode.</p>
     </section>
   );

--- a/docs/dogfooding-v0.4-protocol.md
+++ b/docs/dogfooding-v0.4-protocol.md
@@ -1,0 +1,59 @@
+# v0.4 dogfooding protocol
+
+This protocol creates adoption evidence without importing private work into the repository. Use a
+dedicated local test workspace and record only a short redacted outcome receipt.
+
+## Guardrails
+
+- Run against a recorded package version or exact Git SHA.
+- Use a synthetic project and synthetic content. Do not paste provider credentials, private files,
+  medical/financial data, cookies, headers, or live user conversations.
+- Never treat a mock provider, CI job, browser emulation, or unconfigured provider as real use.
+- Stop on a data-integrity, privacy, confirmation, budget, or unknown-side-effect regression. Create
+  a normal fix PR; do not patch `main` directly.
+
+## Daily sequence (seven days minimum; extend to fourteen for any instability)
+
+1. Start the app, open the same project, and verify its Control Center summary.
+2. Create or advance a bounded Goal, Task, Decision, Outcome, and private project-state fixture.
+3. Review send scope before each text request. Verify that the planned scope and provider receipt
+   agree; do not attach unapproved files or memory.
+4. Exercise a hard budget reservation and a failed/cancelled request path. Confirm no orphan
+   reservation remains.
+5. Use an MCP confirmation fixture: reject replay, expiry, actor/project/tool binding mismatch, and
+   argument mutation. A valid concurrent consume may succeed exactly once.
+6. Induce a provider fault only with a safe fixture. If an external side effect is unknown, require
+   `OUTCOME_UNKNOWN` and confirm that no automatic replay occurred.
+7. Restart twice. Reopen/save the project and verify state, workflow, recovery marker, usage, and
+   audit/event counts remain bounded.
+8. Run a compatible backup/restore fixture and inspect migration version and Doctor output.
+
+## State-growth soak
+
+Before release review, run the deterministic fixture to produce hundreds of synthetic state,
+workflow, memory, usage, receipt, and reservation records. It must prove all of the following:
+
+- no active orphan reservation after settlement or failure;
+- no stale confirmation is accepted;
+- no recovery session remains stuck after its explicit close/restore path;
+- no duplicate usage record for an idempotent completion path;
+- SQLite integrity is `ok` and migration receipt is intact; and
+- audit/event growth is linear and bounded by the number of generated operations.
+
+The fixture is engineering evidence only. It does not represent months of personal use.
+
+## Redacted operator receipt
+
+```text
+date_utc:
+version_or_sha:
+environment: Windows version / browser only
+provider: configured provider name or BLOCKED_EXTERNAL
+workflow: restart | project reopen | budget | confirmation | fault | restore | doctor
+result: PASS | FAIL | BLOCKED_EXTERNAL
+failure_category: CODE_TEST_FAILURE | DEPENDENCY_FAILURE | PLATFORM_FAILURE | WORKFLOW_CONFIGURATION | EXTERNAL_SERVICE | INCONCLUSIVE
+next_action:
+```
+
+At day 7, review all receipts. Extend through day 14 for a failure, an unreviewed external block,
+or a materially changed SHA. Do not call the protocol complete merely because the calendar elapsed.

--- a/docs/persistent-project-state.md
+++ b/docs/persistent-project-state.md
@@ -25,10 +25,15 @@ The repository ignores SQLite databases and common private-state directories.
 Project state is not stored in the generic Memory table. Each project gets a physically separate private SQLite database under the runtime data directory:
 
 ```text
-data/private/project-state/<tenant-scope>/<project-id>/state.sqlite3
+data/private/p/<tenant-scope>/<opaque-project-key>/s.db
 ```
 
-The public implementation knows only the generic project ID and state protocol. A project database contains only that project's current state, version history, experience ledger, workflow runs, and transition receipts.
+The `opaque-project-key` is a compact one-way key derived from a validated project ID; a raw
+project ID is never embedded in a new storage path. Existing pre-v0.4 databases under
+`data/private/project-state/<tenant-scope>/<project-id>/state.sqlite3` are discovered only inside
+that fixed legacy root, copied into the new private location on first use, and left in place as a
+rollback source. A project database contains only that project's current state, version history,
+experience ledger, workflow runs, and transition receipts.
 
 Sharing the persistence engine does **not** mean sharing project data. For example:
 

--- a/docs/v0.4-real-world-readiness.md
+++ b/docs/v0.4-real-world-readiness.md
@@ -1,0 +1,52 @@
+# v0.4 real-world readiness
+
+This is an evidence ledger for the v0.4 release-candidate process. It does not turn a mock, a
+CI job, or a missing external dependency into a real-world result.
+
+## Status vocabulary
+
+- `VERIFIED`: repeatable evidence exists for the named scope.
+- `VERIFIED_WITH_LIMITATIONS`: the named scope passed, with the stated boundary still open.
+- `BLOCKED_EXTERNAL`: the required real dependency, credential, device, or custody is unavailable.
+- `REGRESSION_FOUND`: a reproducible fault exists and blocks the named scope.
+- `NOT_APPLICABLE`: the check does not apply to this product profile or decision.
+
+## Baseline and current RC gate
+
+The merged daily-use hardening baseline is `4efbf67981b4316a9e45cb8d54cb83b7d77c912b`
+(PR #97). The v0.4 readiness branch must receive a new pull request and its own exact-commit
+CI evidence. A passing result for the baseline is not evidence for a later SHA.
+
+| Area | Status | Evidence and limitation |
+| --- | --- | --- |
+| Database migrations 6/7/8 | `VERIFIED` | Baseline migration matrix covers v5 to v6 to v7 to v8, preservation, interrupted migration fail-closed behavior, and backup/restore. The RC branch adds no main-schema migration. |
+| Private project state compatibility | `VERIFIED` | The RC changes new private-state storage to an opaque keyed directory, rejects path segments, and copies a legacy project database without deleting it. The focused test covers preservation and Windows path limits. |
+| Project Control Center, governance, budget, recovery, memory | `VERIFIED` | Deterministic baseline suites cover project state/workflow, confirmation binding and single consume, reservations, fault semantics, send scope, recovery, and memory governance. The RC must rerun them remotely for its exact SHA. |
+| Core data export and erase | `VERIFIED_WITH_LIMITATIONS` | The Settings flow downloads a credential-free core database export and requires an exact typed confirmation before atomic core-database erase. It deliberately retains private project databases, project-native stores, workspace files, archives, and server credentials; it is not a whole-device erase. |
+| Browser Doctor and update guidance | `VERIFIED_WITH_LIMITATIONS` | Settings can download a redacted Doctor report and links the established Windows update/rollback procedure. It does not execute an installer, signing operation, or Docker command from the browser. |
+| Real Ollama provider restart | `VERIFIED_WITH_LIMITATIONS` | A local loopback Ollama model (`qwen3:8b-q4_K_M`) completed the isolated no-key smoke: unconfigured start, live text turn, restart, and continued conversation. The run did not expose prompt output or credentials. It did not prove cross-provider switching or a long-lived daily workflow. |
+| OpenAI and Anthropic real-provider cycle | `BLOCKED_EXTERNAL` | No credential was read, printed, or inferred. A real cycle is only eligible when the operator has configured a provider and explicitly chooses to run it. |
+| Real Windows distribution and update/rollback | `VERIFIED_WITH_LIMITATIONS` | The exact-SHA platform contract can verify repository Docker/distribution definitions. A local Docker Desktop installation/update/rollback exercise remains external. |
+| Signing custody | `BLOCKED_EXTERNAL` | The distribution contract correctly reports `SIGNING_EXTERNAL_NOT_CONFIGURED`; no certificate or release custody is present in the repository. |
+| Playwright and keyboard accessibility | `VERIFIED_WITH_LIMITATIONS` | Baseline remote Playwright/accessibility checks passed. The RC’s new Settings controls require fresh exact-SHA browser and accessibility workflow evidence. A real screen-reader session remains external. |
+| Physical mobile validation | `BLOCKED_EXTERNAL` | No physical device was available for this run. Browser/mobile emulation is not a substitute. |
+| Seven-to-fourteen day dogfooding | `VERIFIED_WITH_LIMITATIONS` | The protocol is defined below and the deterministic soak harness is a release gate. No elapsed user-use period is claimed until dated operator records exist. |
+
+## Required external readout
+
+Record only outcome-level facts: operating system/version, app SHA or package version, workflow,
+result, failure category, and next action. Do not record provider keys, cookies, headers,
+conversations, memory text, full diagnostic reports, or user file contents.
+
+## RC recommendation rule
+
+The recommendation may be **v0.4 RC candidate**, not final daily-use certification, only after:
+
+1. the readiness PR has an exact head SHA;
+2. all required remote checks for that SHA pass, including new regression coverage;
+3. Code Scanning has no unresolved release-blocking finding for the RC diff;
+4. the PR diff, review threads, and repository rules are clean; and
+5. the deterministic state-growth soak is green.
+
+External blocks above remain separately visible. They do not invalidate deterministic engineering
+evidence, and deterministic engineering evidence does not claim to replace them.

--- a/docs/v0.4-release-scope.md
+++ b/docs/v0.4-release-scope.md
@@ -1,0 +1,46 @@
+# v0.4 release-candidate scope
+
+## Objective
+
+Turn the merged daily-use hardening baseline into a reviewable v0.4 RC through exact-SHA remote
+verification, a bounded real-world validation protocol, and minimum safe data/support controls.
+
+## Included in this RC readiness work
+
+- migrations 6/7/8 evidence and compatibility safety;
+- Project Control Center, governed MCP confirmation, budget reservation, provider faults, send-scope
+  privacy, recovery, memory governance, and doctor evidence;
+- Windows distribution contract review, explicit signing limitation, and user-facing update/rollback
+  guidance;
+- focused privacy-safe core data export/erase controls and a browser-downloadable redacted Doctor
+  report;
+- exact-SHA CI, CodeQL, Dependency Review, Platform Readiness, v0.4 hardening, Playwright,
+  accessibility, migration, governance, budget, provider-fault, and send-scope gates; and
+- a deterministic state-growth soak plus the 7–14 day dogfooding protocol.
+
+## Explicitly excluded
+
+- Gemini or any new provider;
+- cloud accounts, billing, or managed service work;
+- voice redesign or a new voice workflow;
+- agent swarm, marketplace, new plugins, or a plugin platform;
+- domain-specific product work;
+- a visual UI rewrite; and
+- claiming real-provider, signed-distribution, physical-device, or screen-reader results without
+  those external conditions actually being present.
+
+## Version and delivery discipline
+
+This readiness branch does not change the published `0.3.0` version merely to label a candidate.
+The version bump and release artifact are separate, reviewable release decisions after the RC gate.
+No commit may be pushed directly to `main`; fixes use normal pull requests and a changed head SHA
+invalidates earlier exact-SHA pass evidence.
+
+## Exit conditions
+
+1. All required checks pass for the final PR head SHA.
+2. The PR has no unresolved review thread, conflict, or ruleset/branch-protection violation.
+3. Code Scanning and dependency results are classified and resolved without mechanical reruns.
+4. The post-merge main SHA receives its own deterministic verification and soak result.
+5. The release note distinguishes verified engineering, verified-with-limitations, and external
+   blocks using `docs/v0.4-real-world-readiness.md`.

--- a/packages/core/src/personal_ai_os_core/projects.py
+++ b/packages/core/src/personal_ai_os_core/projects.py
@@ -45,6 +45,13 @@ class ProjectRegistry:
             raise ValueError(f"Project already registered: {project_id}")
         self._plugins[project_id] = plugin
 
+    def unregister(self, project_id: str) -> None:
+        """Remove a runtime-only user project after its persisted record was explicitly erased."""
+        try:
+            del self._plugins[project_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown project: {project_id}") from exc
+
     def get(self, project_id: str) -> ProjectPlugin:
         try:
             return self._plugins[project_id]


### PR DESCRIPTION
## v0.4 real-world readiness closure

Base: `4efbf67981b4316a9e45cb8d54cb83b7d77c912b` (merged PR #97)
Head: `83b71d6d2f834e4c2960f1b5e321d0380dd4249b`

### Scope
- Resolves the Code Scanning path-injection surface in private project state: validated project IDs use a compact 128-bit opaque key, legacy raw-name databases are discovered only under the fixed legacy root, copied atomically, and retained as rollback sources. This keeps the SQLite journal path safe on deep Windows data roots.
- Adds a deliberately scoped, credential-free core-data export and explicitly confirmed core-database erase. It does not claim to erase private project databases, project-native stores, workspace files, backups, credentials, or access-control configuration.
- Adds a browser-downloadable redacted Doctor report and existing Windows update/rollback guidance in Settings.
- Adds a deterministic state-growth soak and a redacted 7-14 day dogfooding protocol. No version bump, provider, Cloud, Voice, swarm, marketplace, or plugin work is included.

### Hardening evidence represented by this RC
- migrations 6/7/8: preservation, interrupted fail-closed behavior, and backup/restore remain required exact-SHA gates (this PR adds no main-schema migration);
- Project Control Center, governance/MCP confirmation (replay, expiry, binding and single consume), budget reservation/concurrency, execution recovery and `OUTCOME_UNKNOWN` no-auto-replay semantics;
- provider-fault handling, send-scope planned-versus-provider-payload privacy invariant, and memory governance;
- Windows distribution contract and Doctor; and
- Playwright/Chromium, keyboard accessibility, migration matrix, governance adversarial, budget concurrency, provider-fault injection, and privacy/send-scope workflows must run for this head.

### Local verification
- `pytest apps/api/tests -q --disable-warnings` (controlled deep Windows TEMP root)
- `python scripts/check_internal_versions.py`
- `pnpm --filter @personal-ai-os/web typecheck`
- `pnpm --filter @personal-ai-os/web build`
- Focused deep-path state/workflow/state-growth soak: 17 passed.

### Known external limitations (not represented as CI success)
- Real no-key Ollama restart/text smoke was completed in an isolated local fixture; OpenAI and Anthropic real cycles remain blocked until an operator explicitly configures credentials.
- Docker Desktop installation/update/rollback, signing certificate custody, physical device testing, and a real screen-reader session are separate manual/external validations.
- The 7-14 day protocol is defined, but elapsed long-term user adoption is not claimed.

Every prior PASS applies only to its tested SHA. A changed PR head invalidates old exact-SHA evidence.