### PR TITLE
fix: align Doctor with canonical database path

### DIFF
--- a/apps/api/src/personal_ai_os/config.py
+++ b/apps/api/src/personal_ai_os/config.py
@@ -11,6 +11,8 @@ from personal_ai_os_core import DeploymentMode, PlanId
 
 DEFAULT_REALTIME_ENDPOINT = "https://api.openai.com/v1/realtime/calls"
 DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434/v1/chat/completions"
+CANONICAL_DATABASE_FILENAME = "personal_ai_os.db"
+LEGACY_DATABASE_FILENAMES = ("personal-ai-os.db",)
 
 
 def _csv(value: str) -> tuple[str, ...]:
@@ -222,7 +224,7 @@ class Settings:
 
     @property
     def database_path(self) -> Path:
-        return self.data_dir / "personal_ai_os.db"
+        return self.data_dir / CANONICAL_DATABASE_FILENAME
 
     @property
     def realtime_key(self) -> str | None:

--- a/apps/api/tests/test_doctor.py
+++ b/apps/api/tests/test_doctor.py
@@ -2,14 +2,39 @@ import importlib.util
 import json
 from pathlib import Path
 
+from personal_ai_os.config import (
+    CANONICAL_DATABASE_FILENAME,
+    LEGACY_DATABASE_FILENAMES,
+    Settings,
+)
+from personal_ai_os.db import Database, MIGRATIONS
 
-def _doctor_module():
-    path = Path(__file__).parents[3] / "scripts" / "doctor.py"
-    spec = importlib.util.spec_from_file_location("personal_ai_os_doctor", path)
+
+def _script_module(filename: str, name: str):
+    path = Path(__file__).parents[3] / "scripts" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _doctor_module():
+    return _script_module("doctor.py", "personal_ai_os_doctor")
+
+
+def _migrated_database(data_dir: Path) -> Database:
+    settings = Settings(
+        data_dir=data_dir,
+        cors_origins=("http://localhost:3000",),
+        openai_models=("openai-test",),
+        anthropic_models=("anthropic-test",),
+        default_provider="openai",
+        default_model="openai-test",
+    )
+    database = Database(settings.database_path)
+    database.migrate()
+    return database
 
 
 def test_doctor_report_is_safe_to_share_and_excludes_secret_values(tmp_path: Path, monkeypatch) -> None:
@@ -41,3 +66,65 @@ def test_doctor_redacts_malformed_update_metadata(tmp_path: Path) -> None:
     (install_dir / "update-state.json").write_text('{"status":"private conversation text"}', encoding="utf-8")
     report = _doctor_module().collect_report(tmp_path / "data", install_dir)
     assert report["update"] == {"metadata_present": True, "status": "UNAVAILABLE_OR_REDACTED"}
+
+
+def test_doctor_uses_the_canonical_runtime_database_path_and_migration_version(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    database = _migrated_database(data_dir)
+
+    report = _doctor_module().collect_report(data_dir)
+
+    assert database.path == data_dir / CANONICAL_DATABASE_FILENAME
+    assert database.path.is_file()
+    assert report["database"] == {
+        "status": "ok",
+        "integrity": "ok",
+        "migration_version": max(version for version, _ in MIGRATIONS),
+        "location": "canonical",
+    }
+
+
+def test_doctor_reports_a_missing_canonical_database_without_guessing(tmp_path: Path) -> None:
+    report = _doctor_module().collect_report(tmp_path / "missing")
+
+    assert report["database"] == {
+        "status": "missing",
+        "integrity": "not_applicable",
+        "migration_version": 0,
+        "location": "canonical",
+    }
+
+
+def test_doctor_reads_but_never_moves_a_legacy_database_path(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    legacy_path = data_dir / LEGACY_DATABASE_FILENAMES[0]
+    legacy_database = Database(legacy_path)
+    legacy_database.migrate()
+
+    report = _doctor_module().collect_report(data_dir)
+
+    assert report["database"] == {
+        "status": "legacy_detected",
+        "integrity": "ok",
+        "migration_version": max(version for version, _ in MIGRATIONS),
+        "location": "legacy",
+    }
+    assert legacy_path.is_file()
+    assert not (data_dir / CANONICAL_DATABASE_FILENAME).exists()
+
+
+def test_backup_and_restore_preserve_the_canonical_database_path(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _migrated_database(data_dir)
+    backup_module = _script_module("backup-data.py", "personal_ai_os_backup")
+    restore_module = _script_module("restore-data.py", "personal_ai_os_restore")
+
+    archive = backup_module.build_backup(data_dir, tmp_path / "backups")
+    restored_dir = tmp_path / "restored-data"
+    prior = restore_module.restore(archive, restored_dir)
+    report = _doctor_module().collect_report(restored_dir)
+
+    assert prior is None
+    assert (restored_dir / CANONICAL_DATABASE_FILENAME).is_file()
+    assert report["database"]["status"] == "ok"
+    assert report["database"]["migration_version"] == max(version for version, _ in MIGRATIONS)

--- a/docs/transfer-and-backup.md
+++ b/docs/transfer-and-backup.md
@@ -4,6 +4,11 @@ Personal AI OS keeps runtime state under `PERSONAL_AI_OS_DATA_DIR` (normally `da
 Provider keys and access passwords are host secrets and are deliberately excluded from every
 backup and transfer archive.
 
+The canonical core database is always `PERSONAL_AI_OS_DATA_DIR/personal_ai_os.db`.
+Backup and restore preserve that file together with the rest of the data directory. Doctor reads
+that canonical location; if it finds the former diagnostic-only `personal-ai-os.db` name instead,
+it reports it as legacy without moving or deleting user data.
+
 ## Create a consistent data backup
 
 The backup command uses SQLite's online backup API, so it can snapshot a running local database

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -10,17 +10,54 @@ from importlib import metadata
 from pathlib import Path
 from typing import Any
 
+try:
+    from personal_ai_os.config import CANONICAL_DATABASE_FILENAME, LEGACY_DATABASE_FILENAMES
+except ModuleNotFoundError:
+    # Keep the support script runnable from an uninstalled source checkout.
+    CANONICAL_DATABASE_FILENAME = "personal_ai_os.db"
+    LEGACY_DATABASE_FILENAMES = ("personal-ai-os.db",)
 
-def _database_health(path: Path) -> dict[str, Any]:
+
+def _database_health(path: Path, *, location: str) -> dict[str, Any]:
     if not path.exists():
-        return {"status": "missing", "integrity": "not_applicable", "migration_version": 0}
+        return {
+            "status": "missing",
+            "integrity": "not_applicable",
+            "migration_version": 0,
+            "location": location,
+        }
     try:
         with sqlite3.connect(path) as connection:
             integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
             version = connection.execute("SELECT COALESCE(MAX(version), 0) FROM schema_migrations").fetchone()[0]
-        return {"status": "ok" if integrity == "ok" else "attention", "integrity": integrity, "migration_version": int(version)}
+        return {
+            "status": "ok" if integrity == "ok" else "attention",
+            "integrity": integrity,
+            "migration_version": int(version),
+            "location": location,
+        }
     except sqlite3.Error:
-        return {"status": "attention", "integrity": "unavailable", "migration_version": None}
+        return {
+            "status": "attention",
+            "integrity": "unavailable",
+            "migration_version": None,
+            "location": location,
+        }
+
+
+def _database_report(data_dir: Path) -> dict[str, Any]:
+    canonical = data_dir / CANONICAL_DATABASE_FILENAME
+    if canonical.exists():
+        return _database_health(canonical, location="canonical")
+
+    for filename in LEGACY_DATABASE_FILENAMES:
+        legacy = data_dir / filename
+        if legacy.exists():
+            report = _database_health(legacy, location="legacy")
+            report["status"] = "legacy_detected"
+            return report
+
+    return _database_health(canonical, location="canonical")
 
 
 def _port_state(port: int) -> str:
@@ -66,7 +103,6 @@ def _update_state(path: Path) -> dict[str, object]:
 def collect_report(data_dir: Path, install_dir: Path | None = None) -> dict[str, Any]:
     data_dir = data_dir.resolve()
     install_dir = (install_dir or data_dir.parent).resolve()
-    database = data_dir / "personal-ai-os.db"
     free = shutil.disk_usage(data_dir if data_dir.exists() else data_dir.parent).free
     provider_state = {
         "openai": bool(os.getenv("PERSONAL_AI_OS_OPENAI_API_KEY")),
@@ -88,7 +124,7 @@ def collect_report(data_dir: Path, install_dir: Path | None = None) -> dict[str,
             "writable": os.access(data_dir if data_dir.exists() else data_dir.parent, os.W_OK),
             "free_bytes": free,
         },
-        "database": _database_health(database),
+        "database": _database_report(data_dir),
         "providers": {"configured": provider_state, "values_exposed": False},
         "ollama": {"configured": provider_state["ollama_enabled"], "loopback_port": _port_state(11434)},
         "ports": {"api_8000": _port_state(8000), "web_3000": _port_state(3000)},


### PR DESCRIPTION
## Summary
- Doctor no longer hard-codes the database filename.
- The canonical runtime database path is shared with Doctor.
- The former legacy filename is detected read-only only; it is never moved or deleted.
- No database migration and no user-data modification are performed.

## Verification
- Focused Doctor regression tests passed.
- Full API test suite, compileall, and Doctor smoke passed.