### PR TITLE
chore: keep Node types aligned with Node 24 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- keep `@types/node` on the Node 24 major line while the validated frontend CI runtime remains Node 24
- ignore only semver-major updates for `@types/node`; minor/patch updates within the current major remain enabled

## Rationale

PR #92 attempted to move `@types/node` from 24.x to 26.x while `.github/workflows/ci.yml` still pins `actions/setup-node` to `node-version: "24"`. Keeping the type definitions aligned with the validated runtime avoids modeling Node 26-only APIs before an intentional runtime migration.

Supersedes the closed #92 major type-definition bump.